### PR TITLE
Fix hydration errors in ThemeToggle and Sidebar components

### DIFF
--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,20 +1,24 @@
 "use client";
 
+import * as React from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 export default function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  const isDark = theme === "dark";
-  return (
-    <button
-      type="button"
-      aria-label="Toggle theme"
-      onClick={() => setTheme(isDark ? "light" : "dark")}
-      className="hover:bg-accent text-muted-foreground hover:text-accent-foreground inline-flex size-9 items-center justify-center rounded-md transition-colors"
-    >
-      {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
-    </button>
-  );
+	const { resolvedTheme, setTheme } = useTheme();
+	const [mounted, setMounted] = React.useState(false);
+	React.useEffect(() => {
+		setMounted(true);
+	}, []);
+	const isDark = mounted && resolvedTheme === "dark";
+	return (
+		<button
+			type="button"
+			aria-label="Toggle theme"
+			onClick={() => setTheme(isDark ? "light" : "dark")}
+			className="hover:bg-accent text-muted-foreground hover:text-accent-foreground inline-flex size-9 items-center justify-center rounded-md transition-colors"
+		>
+			{mounted ? (isDark ? <Sun className="size-4" /> : <Moon className="size-4" />) : <Moon className="size-4" />}
+		</button>
+	);
 }
-


### PR DESCRIPTION
## Summary
- Resolves hydration mismatch errors in the `ThemeToggle` component by delaying rendering until after client mount
- Improves sidebar state persistence and hydration handling to avoid UI flicker and state clobbering

## Changes

### ThemeToggle Component
- Uses `resolvedTheme` instead of `theme` from `next-themes` for accurate theme detection
- Adds a `mounted` state to delay rendering theme-dependent UI until after client-side hydration
- Conditionally renders icons only after mount to prevent hydration mismatch

### Sidebar Component
- Refactors sidebar collapsed state persistence logic
- Introduces a `hasPersistedRef` to prevent overwriting persisted state on initial render
- Separates effects for setting CSS variable and persisting state to localStorage
- Maintains keyboard shortcut (Ctrl+B) for toggling sidebar collapse
- Avoids animation on first paint by delaying mount state

## Test plan
- Verify no hydration errors or warnings in console on initial load
- Confirm theme toggle button switches themes correctly without UI flicker
- Ensure sidebar collapsed state persists across page reloads
- Test keyboard shortcut Ctrl+B toggles sidebar collapse
- Check CSS variable `--sb-width` updates correctly with sidebar state changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5d1ab228-fb65-4ec0-8399-bc5c72e6bf87