### PR TITLE
Fix button size and color styles in app sidebar

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -335,12 +335,13 @@ function ChatList({
               void onDelete(c.id);
             }}
             className={cn(
-              "absolute right-2 top-1/2 -translate-y-1/2 inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-destructive",
-              "transition-all duration-150 group-hover:opacity-100 group-hover:border-destructive/60",
-              "bg-destructive/10 hover:bg-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive",
-              "hover:text-destructive-foreground focus-visible:text-destructive-foreground",
-              "disabled:cursor-progress disabled:bg-muted disabled:text-muted-foreground",
-              deletingId === c.id ? "opacity-100" : "opacity-0",
+              "absolute right-2 top-1/2 -translate-y-1/2 inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent",
+              "text-destructive transition-all duration-150",
+              "opacity-100 md:opacity-0 md:group-hover:opacity-100",
+              "hover:bg-destructive/10 hover:text-destructive",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40",
+              "disabled:cursor-progress disabled:text-muted-foreground",
+              (deletingId === c.id || isActive) && "md:opacity-100",
             )}
             aria-label="Delete chat"
             disabled={deletingId === c.id}


### PR DESCRIPTION
## Summary
- Adjusts the size and color styles of the delete chat button in the app sidebar
- Improves consistency and visual feedback for button states including hover, focus, disabled, and active

## Changes

### UI Component Updates
- Modified button dimensions from 8x8 to 7x7 for a more compact appearance
- Refined color classes to use consistent destructive color shades with appropriate opacity
- Updated opacity behavior to show button only on hover or when active/deleting
- Improved focus-visible ring styling for better accessibility feedback
- Removed redundant border and background styles for cleaner look

## Test plan
- [x] Verify delete button size matches design specifications
- [x] Confirm button color changes on hover, focus, and disabled states
- [x] Ensure button visibility toggles correctly on group hover and active states
- [x] Test accessibility focus ring appears as expected
- [x] Validate delete functionality remains intact with updated styles

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/10156bd7-4031-4dde-981d-64971da677a2