### PR TITLE
feat: guide guests through OpenRouter setup

### DIFF
--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -1,18 +1,9 @@
 import { getUserContext } from "@/lib/auth-server";
 import SettingsPageClient from "@/components/settings-page-client";
-import DashboardAccessFallback from "@/components/dashboard-access-fallback";
 
 export const dynamic = "force-dynamic";
 
 export default async function SettingsPage() {
-	const { isGuest } = await getUserContext();
-	if (isGuest) {
-		return (
-			<DashboardAccessFallback
-				title="Sign in to manage settings"
-				description="Account preferences are only available once you're authenticated."
-			/>
-		);
-	}
-	return <SettingsPageClient />;
+	const context = await getUserContext();
+	return <SettingsPageClient isGuest={context.isGuest} />;
 }

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -325,7 +325,12 @@ function ChatList({
 	deletingId: string | null;
 }) {
 	if (isLoading && chats.length === 0) {
-		return <p className="px-2 text-xs text-muted-foreground">Syncing chats…</p>;
+		return (
+			<div className="mx-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+				Syncing chats… If this message sticks around, Electric SQL may be offline. New conversations will still appear here
+				while we fall back to local storage.
+			</div>
+		);
 	}
 	if (chats.length === 0) return <p className="px-2 text-xs text-muted-foreground">No chats</p>;
 	return (

--- a/apps/web/src/components/chat-room.tsx
+++ b/apps/web/src/components/chat-room.tsx
@@ -51,6 +51,7 @@ export default function ChatRoom({ chatId, initialMessages }: ChatRoomProps) {
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelOptions, setModelOptions] = useState<{ value: string; label: string; description?: string }[]>([]);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const missingKeyToastRef = useRef<string | number | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(searchParamsString);
@@ -110,6 +111,24 @@ export default function ChatRoom({ chatId, initialMessages }: ChatRoomProps) {
       }
     })();
   }, [fetchModels]);
+
+  useEffect(() => {
+    if (!apiKey) {
+      if (missingKeyToastRef.current == null) {
+        missingKeyToastRef.current = toast.warning("Add your OpenRouter API key", {
+          description: "Open settings to paste your key and start chatting.",
+          duration: Infinity,
+          action: {
+            label: "Settings",
+            onClick: () => router.push("/dashboard/settings"),
+          },
+        });
+      }
+    } else if (missingKeyToastRef.current !== null) {
+      toast.dismiss(missingKeyToastRef.current);
+      missingKeyToastRef.current = null;
+    }
+  }, [apiKey, router]);
 
   const handleSaveApiKey = useCallback(
     async (key: string) => {

--- a/apps/web/src/components/settings-page-client.tsx
+++ b/apps/web/src/components/settings-page-client.tsx
@@ -1,26 +1,68 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { AccountSettingsModal } from "@/components/account-settings-modal";
 import ThemeSelector from "@/components/settings/theme-selector";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-export default function SettingsPageClient() {
+type SettingsPageClientProps = {
+	isGuest?: boolean;
+};
+
+export default function SettingsPageClient({ isGuest }: SettingsPageClientProps) {
   const [open, setOpen] = useState(false);
-  return (
-    <div className="mx-auto max-w-4xl p-6">
-      <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-      <p className="text-muted-foreground mt-2">Manage your application preferences and account.</p>
+  const accountDisabled = Boolean(isGuest);
 
-      <div className="mt-6 grid gap-6">
+  return (
+    <div className="mx-auto max-w-4xl p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <p className="text-muted-foreground mt-2">Manage your application preferences and account.</p>
+      </div>
+
+      {accountDisabled ? (
+        <div className="border-l-4 border-amber-500 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:border-amber-400 dark:bg-amber-400/10 dark:text-amber-200">
+          You&apos;re exploring OpenChat in guest mode. Saved account settings and team sharing require signing in, but you can still
+          store an OpenRouter API key in your browser for testing.
+        </div>
+      ) : null}
+
+      <div className="grid gap-6">
         <section className="rounded-xl border p-4">
           <h2 className="text-sm font-medium">Account</h2>
           <p className="text-muted-foreground mt-1 text-sm">Update your profile, emails, and security.</p>
           <div className="mt-3">
-            <Button variant="outline" onClick={() => setOpen(true)}>
-              Manage account
-            </Button>
+            {accountDisabled ? (
+              <Button variant="outline" asChild>
+                <Link href="/auth/sign-in">Sign in to manage your account</Link>
+              </Button>
+            ) : (
+              <Button variant="outline" onClick={() => setOpen(true)}>
+                Manage account
+              </Button>
+            )}
           </div>
+        </section>
+
+        <section className="rounded-xl border p-4">
+          <h2 className="text-sm font-medium">OpenRouter API</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Generate an API key at
+            {" "}
+            <a
+              href="https://openrouter.ai/keys"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary font-medium underline-offset-4 hover:underline"
+            >
+              openrouter.ai/keys
+            </a>
+            {" "}
+            and save it when prompted in the chat composer. Keys are stored locally in your browser.
+          </p>
+          <p className={cn("text-xs text-muted-foreground mt-2", accountDisabled && "italic")}>We&apos;ll keep asking until a key is added.</p>
         </section>
 
         <section className="rounded-xl border p-4">
@@ -30,7 +72,7 @@ export default function SettingsPageClient() {
         </section>
       </div>
 
-      <AccountSettingsModal open={open} onClose={() => setOpen(false)} />
+      <AccountSettingsModal open={open && !accountDisabled} onClose={() => setOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep a persistent toast in the chat composer prompting users to add an OpenRouter API key, with quick link to settings
- let guest accounts open the settings page; show guidance + sign-in CTA instead of the full account modal
- clarify sidebar syncing state so users know Electric SQL might be offline

## Testing
- bun check
- bunx turbo run build --filter=server --filter=web