### PR TITLE
Potential fix for code scanning alert no. 5: Improper code sanitization

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -9,6 +9,25 @@ import Script from "next/script";
 import type { ChatSummary } from "@/types/server-router";
 export const dynamic = "force-dynamic";
 
+const charMap = {
+    '<': '\\u003C',
+    '>': '\\u003E',
+    '/': '\\u002F',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\0': '\\0',
+    '\u2028': '\\u2028',
+    '\u2029': '\\u2029'
+};
+
+function escapeUnsafeChars(str: string): string {
+    return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029/\\]/g, x => charMap[x] || x);
+}
+
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
 	const { userId } = await getUserContext();
 
@@ -29,7 +48,7 @@ export default async function DashboardLayout({ children }: { children: ReactNod
 			</div>
 			<main className="relative flex min-h-0 flex-1 flex-col overflow-hidden md:ml-[var(--sb-width)] transition-[margin] duration-300 ease-in-out w-full">
 		<Script id="oc-user-bootstrap" strategy="afterInteractive">
-			{`(() => { const u = ${JSON.stringify(userId)}; window.__DEV_USER_ID__ = u; window.__OC_GUEST_ID__ = u; })();`}
+			{`(() => { const u = ${escapeUnsafeChars(JSON.stringify(userId))}; window.__DEV_USER_ID__ = u; window.__OC_GUEST_ID__ = u; })();`}
 		</Script>
 				<div className="pointer-events-auto absolute right-4 top-4 z-20 flex items-center gap-1 rounded-xl border bg-card/80 px-2 py-1.5 shadow-md backdrop-blur">
 					<Link


### PR DESCRIPTION
Potential fix for [https://github.com/opentech1/openchat/security/code-scanning/5](https://github.com/opentech1/openchat/security/code-scanning/5)

To fix this issue, any potentially unsafe characters in the string returned by `JSON.stringify(userId)` should be escaped before embedding it into the JavaScript code in the template string. This is best achieved by defining an `escapeUnsafeChars` function that replaces unsafe characters (such as `<`, `>`, `/`, `\u2028`, `\u2029`, and others listed in the provided example) with their Unicode escapes. We should add this function inside the same file, near the top, and then use it in place of `JSON.stringify(userId)` within the template string at line 32. No external dependencies are needed for this, and the change does not affect existing functionality except to add better security.

Required changes:
- Define an `escapeUnsafeChars` utility function in the file, above its usage.
- Replace `${JSON.stringify(userId)}` with `${escapeUnsafeChars(JSON.stringify(userId))}` in the inline script template string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
