### PR TITLE
docs(server): note legacy key env

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -22,6 +22,8 @@ OPENROUTER_API_KEY_SECRET=
 # Optional overrides
 OPENROUTER_BASE_URL=
 OPENROUTER_SCOPE=
+# Base64url-encoded 32-byte key for decrypting legacy SHA-256 tokens (set once during migration).
+OPENROUTER_LEGACY_KEY=
 
 # Development helpers
 DEV_ALLOW_HEADER_BYPASS=1


### PR DESCRIPTION
Adds OPENROUTER_LEGACY_KEY to apps/server/.env.example so operators know to supply a base64url legacy key during migration.