### PR TITLE
refactor(chat): batch sidebar updates and improve sorting

### DIFF
--- a/apps/server/src/lib/posthog.ts
+++ b/apps/server/src/lib/posthog.ts
@@ -29,6 +29,10 @@ const BASE_SUPER_PROPERTIES = Object.freeze({
 	deployment_region: DEPLOYMENT_REGION,
 });
 
+const POSTHOG_FLUSH_AT_RAW = Number(process.env.POSTHOG_FLUSH_AT ?? 10);
+const POSTHOG_FLUSH_AT =
+	Number.isFinite(POSTHOG_FLUSH_AT_RAW) && POSTHOG_FLUSH_AT_RAW > 1 ? POSTHOG_FLUSH_AT_RAW : 10;
+
 function buildClient() {
 	const apiKey = process.env.POSTHOG_API_KEY;
 	if (!apiKey) return null;
@@ -36,7 +40,7 @@ function buildClient() {
 	const host = process.env.POSTHOG_HOST || "https://us.i.posthog.com";
 	client = new PostHog(apiKey, {
 		host,
-		flushAt: 1,
+		flushAt: POSTHOG_FLUSH_AT,
 		flushInterval: 5_000,
 	});
 	client.register(BASE_SUPER_PROPERTIES);

--- a/apps/web/src/lib/guest.client.ts
+++ b/apps/web/src/lib/guest.client.ts
@@ -17,18 +17,27 @@ function writeCookie(name: string, value: string) {
 }
 
 function persistGuestId(value: string) {
+	let stored: string | null = null;
 	try {
-		localStorage.setItem(GUEST_ID_STORAGE_KEY, value);
+		stored = localStorage.getItem(GUEST_ID_STORAGE_KEY);
+		if (stored !== value) {
+			localStorage.setItem(GUEST_ID_STORAGE_KEY, value);
+		}
 	} catch {
 		// ignore storage errors (private mode, etc.)
 	}
-	writeCookie(GUEST_ID_COOKIE, value);
+	const cookieValue = readCookie(GUEST_ID_COOKIE);
+	if (cookieValue !== value) {
+		writeCookie(GUEST_ID_COOKIE, value);
+	}
 }
 
 export function ensureGuestIdClient(): string {
 	let id: string | null = null;
+	let stored: string | null = null;
 	try {
-		id = localStorage.getItem(GUEST_ID_STORAGE_KEY);
+		stored = localStorage.getItem(GUEST_ID_STORAGE_KEY);
+		id = stored;
 	} catch {
 		id = null;
 	}
@@ -39,9 +48,14 @@ export function ensureGuestIdClient(): string {
 
 	if (!id) {
 		id = createGuestId();
+		persistGuestId(id);
+	} else {
+		const cookieValue = readCookie(GUEST_ID_COOKIE);
+		if (stored !== id || cookieValue !== id) {
+			persistGuestId(id);
+		}
 	}
 
-	persistGuestId(id);
 	(window as any).__OC_GUEST_ID__ = id;
 	return id;
 }


### PR DESCRIPTION
## Summary
- batch chat index updates and only publish sidebar events when fields actually change
- derive chat timestamps in sidebar with normalized millisecond fields for stable sorting
- persist guest ids without redundant storage writes and make PostHog flush configurable

## Testing
- bun check
- exercised chat create/message flows locally (WS + fallback)