### PR TITLE
fix: include next outputs in turbo cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
 		"build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": ["dist/**", ".output/**"]
+			"outputs": ["dist/**", ".output/**", ".next/**"]
 		},
 		"lint": {
 			"dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary
- add .next directory to turbo build outputs so remote cache restores next artifacts

## Testing
- bun check-types