### PR TITLE
fix(server): update vercel runtime

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -14,7 +14,7 @@ function getApp() {
 }
 
 export const config = {
-	runtime: "nodejs20.x",
+	runtime: "nodejs",
 };
 
 export default function handler(request: Request) {


### PR DESCRIPTION
## Summary
- switch vercel function runtime to 'nodejs' since nodejs20.x is unsupported value

## Testing
- bun check-types