### PR TITLE
Fix issue #70: Support Cmd/Ctrl+B to toggle sidebar

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -17,7 +17,7 @@ export function Sidebar({ className, children, defaultCollapsed = false, ...prop
 	const hasPersistedRef = React.useRef(false);
 	React.useEffect(() => {
 		const onKey = (e: KeyboardEvent) => {
-			if (e.ctrlKey && (e.key === "b" || e.key === "B")) {
+			if ((e.ctrlKey || e.metaKey) && (e.key === "b" || e.key === "B")) {
 				e.preventDefault();
 				setCollapsed((v) => !v);
 			}


### PR DESCRIPTION
## Summary
- Resolves issue #70 by enabling both Ctrl+B and Cmd+B to toggle the sidebar in the web UI.

## Changes
### Core
- Update keyboard shortcut handling in Sidebar to consider metaKey (Command on macOS) along with ctrlKey, ensuring Cmd+B also toggles the sidebar.
- Retains e.preventDefault() to prevent default browser behavior and toggling of the collapsed state.

### Files
- apps/web/src/components/ui/sidebar.tsx

## Test plan
- [x] Manually verify toggling with Ctrl+B (Windows/Linux) and Cmd+B (macOS)
- [x] Ensure default browser behavior is overridden without affecting other shortcuts
- [x] Verify no regression for other keyboard events in the sidebar

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ab30e013-c18d-4a4f-b48c-1b527a81179c

📝 Addresses #70