### PR TITLE
fix(web): whitelist posthog hosts in csp

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -26,7 +26,9 @@ const nextConfig = {
 		const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:3000";
 		const electricUrl = process.env.NEXT_PUBLIC_ELECTRIC_URL || "http://localhost:3010";
 		const authUrl = process.env.BETTER_AUTH_URL;
-		const additionalConnect = [serverUrl, electricUrl, authUrl]
+		const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+		const posthogAssetsHost = "https://us-assets.i.posthog.com";
+		const additionalConnect = [serverUrl, electricUrl, authUrl, posthogHost]
 			.filter(Boolean)
 			.map((url) => {
 				try {
@@ -36,7 +38,20 @@ const nextConfig = {
 				}
 			})
 			.filter(Boolean);
+		if (!additionalConnect.includes(posthogAssetsHost)) {
+			additionalConnect.push(posthogAssetsHost);
+		}
 		const scriptSrc = ["'self'", "'unsafe-inline'", "'unsafe-eval'"];
+		if (additionalConnect.length > 0) {
+			for (const origin of additionalConnect) {
+				if (origin && !scriptSrc.includes(origin)) {
+					scriptSrc.push(origin);
+				}
+			}
+		}
+		if (!scriptSrc.includes(posthogAssetsHost)) {
+			scriptSrc.push(posthogAssetsHost);
+		}
 		const connectSrc = ["'self'", ...additionalConnect, "ws:", "wss:"];
 		const imgSrc = ["'self'", "data:", "blob:", "https://ik.imagekit.io"];
 		const frameSrc = ["'self'"];


### PR DESCRIPTION
## Summary
- include posthog api + asset origins in CSP script/connect directives so analytics can load
- reuse existing allowlist helper for other hosts

## Testing
- bun check-types