### PR TITLE
fix(server): route custom domain requests on vercel

### DIFF
--- a/apps/server/api/[[...path]].ts
+++ b/apps/server/api/[[...path]].ts
@@ -1,0 +1,34 @@
+import { createApp } from "../src/app";
+
+let appInstance: ReturnType<typeof createApp> | null = null;
+
+function getApp() {
+	if (appInstance) return appInstance;
+	try {
+		appInstance = createApp();
+		return appInstance;
+	} catch (error) {
+		console.error("[server] Failed to initialise Elysia app", error);
+		throw error;
+	}
+}
+
+export const config = {
+	runtime: "nodejs",
+};
+
+export default async function handler(request: Request) {
+	const app = getApp();
+	const originalUrl = new URL(request.url);
+	const strippedPath = originalUrl.pathname.replace(/^\/api/, "") || "/";
+	const targetUrl = new URL(strippedPath + originalUrl.search, originalUrl.origin);
+
+	const init: RequestInit = {
+		method: request.method,
+		headers: request.headers,
+		body: request.method === "GET" || request.method === "HEAD" ? null : request.body,
+	};
+
+	const proxiedRequest = new Request(targetUrl.toString(), init);
+	return app.fetch(proxiedRequest);
+}

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/api/$1"
+		}
+	]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,21 @@
 		"build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": ["dist/**", ".output/**", ".next/**"]
+			"outputs": ["dist/**", ".output/**", ".next/**"],
+			"env": [
+				"DATABASE_URL",
+				"DATABASE_URL_UNPOOLED",
+				"ELECTRIC_SECRET",
+				"ELECTRIC_GATEKEEPER_SECRET",
+				"ELECTRIC_SERVICE_URL",
+				"BETTER_AUTH_SECRET",
+				"BETTER_AUTH_URL",
+				"SERVER_INTERNAL_URL",
+				"CORS_ORIGIN",
+				"TRUST_PROXY_FORWARDED",
+				"POSTHOG_API_KEY",
+				"POSTHOG_HOST"
+			]
 		},
 		"lint": {
 			"dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary
- expose the elysia app through an api/[[...path]] catch-all so vercel can serve /, /rpc, /api/auth, etc.
- add vercel rewrites to forward all paths to the handler
- declare server secrets in turbo.json env to keep builds quiet

## Testing
- bun check-types