### PR TITLE
fix(server): avoid listening when running on vercel

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,8 +3,9 @@ import { createApp } from "./app";
 
 const PORT = Number(process.env.PORT || 3000);
 
-const app = createApp();
-
-app.listen(PORT, () => {
-	console.log(`Server is running on http://localhost:${PORT}`);
-});
+if (process.env.VERCEL !== "1" && process.env.VERCEL !== "true") {
+	const app = createApp();
+	app.listen(PORT, () => {
+		console.log(`Server is running on http://localhost:${PORT}`);
+	});
+}


### PR DESCRIPTION
## Summary
- guard the bun dev entrypoint so it doesn’t bind to a port when the Vercel runtime imports it

## Testing
- bun check-types