### PR TITLE
fix(server): use web fetch handler on vercel

### DIFF
--- a/apps/server/api/[[...path]].ts
+++ b/apps/server/api/[[...path]].ts
@@ -4,35 +4,31 @@ let appInstance: ReturnType<typeof createApp> | null = null;
 
 function getApp() {
 	if (appInstance) return appInstance;
-	try {
-		appInstance = createApp();
-		return appInstance;
-	} catch (error) {
-		console.error("[server] Failed to initialise Elysia app", error);
-		throw error;
-	}
+	appInstance = createApp();
+	return appInstance;
 }
 
 export const config = {
 	runtime: "nodejs",
 };
 
-export default async function handler(request: Request) {
-	const app = getApp();
-	const originalUrl = new URL(request.url);
-	const strippedPath = originalUrl.pathname.replace(/^\/api/, "") || "/";
-	const targetUrl = new URL(strippedPath + originalUrl.search, originalUrl.origin);
+export default {
+	async fetch(request: Request) {
+		const app = getApp();
+		const originalUrl = new URL(request.url);
+		const strippedPath = originalUrl.pathname.replace(/^\/api/, "") || "/";
+		const targetUrl = new URL(strippedPath + originalUrl.search, originalUrl.origin);
 
-try {
-	// Preserve the original request (body, headers, method) while swapping the URL
-	const proxiedRequest = new Request(targetUrl.toString(), request);
-	return await app.fetch(proxiedRequest);
-} catch (error) {
-	console.error("[server] request failed", {
-		url: request.url,
-		target: targetUrl.toString(),
-		error,
-	});
-	return new Response("Internal Server Error", { status: 500 });
-}
-}
+		try {
+			const proxiedRequest = new Request(targetUrl.toString(), request);
+			return await app.fetch(proxiedRequest);
+		} catch (error) {
+			console.error("[server] request failed", {
+				url: request.url,
+				target: targetUrl.toString(),
+				error,
+			});
+			return new Response("Internal Server Error", { status: 500 });
+		}
+	},
+};


### PR DESCRIPTION
## Summary
- export a Node runtime function using the fetch web-standard signature so vercel invokes it correctly

## Testing
- bun check-types