### PR TITLE
chore(server): bubble up internal errors

### DIFF
--- a/apps/server/api/[[...path]].ts
+++ b/apps/server/api/[[...path]].ts
@@ -38,7 +38,9 @@ export default {
 				target: targetUrl.toString(),
 				error,
 			});
-			return new Response("Internal Server Error", { status: 500 });
+			const message =
+				error instanceof Error ? error.stack || error.message : typeof error === "string" ? error : "Internal Server Error";
+			return new Response(message, { status: 500 });
 		}
 	},
 };


### PR DESCRIPTION
## Summary
- include the thrown error message/stack in the 500 response so we can debug the node runtime crash

## Testing
- bun check-types