### PR TITLE
fix: compile auth package for vercel node runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docker/secrets/
 coverage/
 test-results/
 tmp/
+packages/auth/dist/

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -74,21 +74,22 @@ if (normalizedInternalUrl) {
 	}
 }
 
-const criticalKeys = [
+const requiredRuntimeKeys = [
 	"DATABASE_URL",
-	"SHADOW_DATABASE_URL",
 	"BETTER_AUTH_SECRET",
 	"BETTER_AUTH_URL",
 	"SERVER_INTERNAL_URL",
 	"CORS_ORIGIN",
 ];
 
+const optionalRuntimeKeys = ["SHADOW_DATABASE_URL"];
+
 const shouldLoadWorkspaceEnv = forceWorkspaceEnv || !skipWorkspaceEnv;
 if (shouldLoadWorkspaceEnv) {
 	loadFiles(workspaceEnvFiles);
 }
 
-const unresolvedCritical = criticalKeys.filter((key) => !process.env[key]);
+const unresolvedCritical = requiredRuntimeKeys.filter((key) => !process.env[key]);
 if (unresolvedCritical.length > 0) {
 	const hint = skipWorkspaceEnv && !forceWorkspaceEnv
 		? "Set them in the runtime environment or export SERVER_REQUIRE_WORKSPACE_ENV=1 to allow workspace-level .env fallbacks."
@@ -100,4 +101,10 @@ if (unresolvedCritical.length > 0) {
 	if (process.env.NODE_ENV !== "test") {
 		console.warn(message);
 	}
+}
+
+const unresolvedOptional = optionalRuntimeKeys.filter((key) => !process.env[key]);
+if (unresolvedOptional.length > 0 && process.env.NODE_ENV !== "test") {
+	const hint = "Shadow database URL is only required for local migrations. Populate SHADOW_DATABASE_URL when running drizzle migrations.";
+	console.warn(`[server:env] Optional environment variables missing: ${unresolvedOptional.join(", ")}. ${hint}`);
 }

--- a/env.server.example
+++ b/env.server.example
@@ -6,6 +6,7 @@ POSTGRES_USER=openchat
 POSTGRES_PASSWORD=replace-with-strong-password
 POSTGRES_DB=openchat
 DATABASE_URL=postgresql://openchat:replace-with-strong-password@openchat-postgres:5432/openchat
+# Optional – required only for running drizzle migrations locally.
 SHADOW_DATABASE_URL=postgresql://openchat:replace-with-strong-password@openchat-postgres:5432/openchat_shadow
 
 # --- ElectricSQL Cloud ------------------------------------------------------

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,21 +3,31 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./auth": "./src/index.ts",
-    "./client": "./src/client.ts",
-    "./next": "./src/next.ts",
-    "./schema": "./src/schema.ts",
-    "./database": "./src/database.ts"
+    ".": "./dist/index.js",
+    "./auth": "./dist/index.js",
+    "./client": "./dist/client.js",
+    "./next": "./dist/next.js",
+    "./schema": "./dist/schema.js",
+    "./database": "./dist/database.js"
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "better-auth": "^1.3.18",
     "drizzle-orm": "^0.44.5",
     "pg": "^8.16.3"
   },
   "devDependencies": {
-    "@types/pg": "^8.11.11"
+    "@types/pg": "^8.11.11",
+    "typescript": "workspace:*"
+  },
+  "scripts": {
+    "build": "bun x tsc -p tsconfig.build.json",
+    "check-types": "bun x tsc --noEmit -p tsconfig.json",
+    "clean": "rm -rf dist"
   }
 }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,8 +3,8 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
-import { resolveDatabaseConfig, warnOnUnresolvedHost } from "./database";
-import * as authSchema from "./schema";
+import { resolveDatabaseConfig, warnOnUnresolvedHost } from "./database.js";
+import * as authSchema from "./schema.js";
 
 const globalSymbol = Symbol.for("openchat.auth.pool");
 const memorySymbol = Symbol.for("openchat.auth.memory");

--- a/packages/auth/src/next.ts
+++ b/packages/auth/src/next.ts
@@ -1,4 +1,4 @@
 import { toNextJsHandler } from "better-auth/next-js";
-import { auth } from "./index";
+import { auth } from "./index.js";
 
 export const { GET, POST } = toNextJsHandler(auth.handler);

--- a/packages/auth/tsconfig.build.json
+++ b/packages/auth/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": true,
+		"outDir": "./dist",
+		"sourceMap": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,17 +1,14 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "declaration": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src/**/*.ts"]
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"verbatimModuleSyntax": false,
+		"noEmit": true,
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- build @openchat/auth to dist and reference compiled entrypoints so node can import it on Vercel
- make shadow database url optional in env bootstrap and clarify template
- keep generated dist out of git

## Testing
- bunx turbo run build --filter=@openchat/auth --filter=server
- node -e "import('@openchat/auth').then(m=>console.log(Object.keys(m)))"],