### PR TITLE
chore(auth): depend on published typescript

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",
-    "typescript": "workspace:*"
+    "typescript": "^5.9.2"
   },
   "scripts": {
     "build": "bun x tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary
- install typescript from npm instead of using workspace:* alias
  so Bun can resolve the dependency during Vercel builds

## Testing
- bunx turbo run build --filter=@openchat/auth --filter=server
