### PR TITLE
fix(server): load compiled bundle without TS shim

### DIFF
--- a/apps/server/api/dist-module.d.ts
+++ b/apps/server/api/dist-module.d.ts
@@ -1,3 +1,0 @@
-declare module "../dist/index.js" {
-	export { createApp } from "../src/app";
-}

--- a/apps/server/api/load-app.ts
+++ b/apps/server/api/load-app.ts
@@ -6,11 +6,14 @@ type AppInstance = ReturnType<AppFactory>;
 let appPromise: Promise<AppInstance> | null = null;
 
 const preferCompiledBundle = process.env.VERCEL === "1" || process.env.VERCEL === "true";
+const compiledBundleSpecifier = "../dist/index.js" as string;
 
 async function loadFactory(): Promise<AppFactory> {
 	if (preferCompiledBundle) {
 		try {
-			const module = await import("../dist/index.js");
+			const module = (await import(compiledBundleSpecifier)) as Partial<{
+				createApp: AppFactory;
+			}>;
 			if (typeof module.createApp === "function") {
 				return module.createApp;
 			}

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -15,5 +15,6 @@
 		"composite": true,
 		"jsx": "react-jsx"
 	},
+	"include": ["src", "api", "test"],
 	"exclude": ["dist"]
 }


### PR DESCRIPTION
## Summary
- stop TypeScript from flagging the compiled bundle import by treating it as a dynamic specifier
- drop the custom dist-module shim now that the import path no longer needs an ambient declaration
- explicitly include api/test directories in the server tsconfig so TypeScript still picks them up

## Testing
- bun check-types --filter=server
- bunx turbo run build --filter=server