### PR TITLE
fix(server): load compiled bundle without TS shim

### DIFF
--- a/apps/server/api/dist-module.d.ts
+++ b/apps/server/api/dist-module.d.ts
@@ -1,3 +1,0 @@
-declare module "../dist/index.js" {
-	export { createApp } from "../src/app";
-}

--- a/apps/server/api/load-app.ts
+++ b/apps/server/api/load-app.ts
@@ -6,21 +6,34 @@ type AppInstance = ReturnType<AppFactory>;
 let appPromise: Promise<AppInstance> | null = null;
 
 const preferCompiledBundle = process.env.VERCEL === "1" || process.env.VERCEL === "true";
+const compiledBundleSpecifier = "../dist/index.js";
 
 async function loadFactory(): Promise<AppFactory> {
 	if (preferCompiledBundle) {
 		try {
-			const module = await import("../dist/index.js");
-			if (typeof module.createApp === "function") {
-				return module.createApp;
+			const module = await import(compiledBundleSpecifier);
+			const createApp = (module as { createApp?: AppFactory }).createApp;
+			if (typeof createApp === "function") {
+				return createApp;
 			}
-			console.warn("[server] Compiled bundle missing createApp export; falling back to source app");
+			throw new Error(
+				"[server] Compiled bundle missing createApp export; ensure dist/index.js re-exports createApp"
+			);
 		} catch (error) {
 			console.error("[server] Failed to load compiled app bundle", error);
+			const cause = error instanceof Error ? error : undefined;
+			const message =
+				"[server] Unable to load compiled app bundle from dist/index.js; rebuild the server package";
+			throw cause ? new Error(message, { cause }) : new Error(message);
 		}
 	}
 
 	// In local development (Bun) importing the TypeScript source is fine.
+	if (preferCompiledBundle) {
+		console.warn("[server] Compiled bundle unavailable; falling back to TypeScript source app module.");
+	} else {
+		console.debug("[server] Using TypeScript source app module (development).");
+	}
 	const module = await import("../src/app");
 	return module.createApp;
 }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -15,5 +15,6 @@
 		"composite": true,
 		"jsx": "react-jsx"
 	},
+	"include": ["src", "api", "test"],
 	"exclude": ["dist"]
 }


### PR DESCRIPTION
## Summary
- import the compiled bundle via dynamic spec and throw when it lacks createApp so node deployments fail fast
- remove the ambient dist-module shim and explicitly compile the api/test directories via tsconfig include

## Testing
- bun check-types --filter=server
- bunx turbo run build --filter=server