### PR TITLE
fix(server): add non-optional api catch-all shim

### DIFF
--- a/apps/server/api/[...path].ts
+++ b/apps/server/api/[...path].ts
@@ -1,0 +1,1 @@
+export { config, default } from "./[[...path]]";


### PR DESCRIPTION
## Summary
- add an explicit `api/[...path].ts` that re-exports the optional catch-all so Vercel routes with at least one path segment resolve the serverless function
- keep `[[...path]].ts` for root-level requests so zero-segment routes keep working

## Testing
- bun check-types --filter=server
- bunx turbo run build --filter=server