### PR TITLE
fix(server): reintroduce optional api catch-all

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,0 +1,9 @@
+import catchAll, { config } from "./[...path]";
+
+export { config };
+
+export default {
+	async fetch(request: Request) {
+		return catchAll.fetch(request);
+	},
+};


### PR DESCRIPTION
## Summary
- keep the existing loader in `[[...path]].ts` and add a thin `[...path].ts` forwarder so `/api/<segments>` resolves too
- add `index.ts` that re-exports the handler for the bare `/api` route

## Testing
- bun check-types --filter=server
- bunx turbo run build --filter=server