### PR TITLE
fix(server): use file extension when importing api catch-all

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,4 +1,4 @@
-import catchAll, { config } from "./[...path]";
+import catchAll, { config } from "./[...path].js";
 
 export { config };
 


### PR DESCRIPTION
## Summary
- update `apps/server/api/index.ts` to import the catch-all module using an explicit `.js` extension so Vercel resolves the compiled file at runtime.

## Testing
- bun check-types --filter=server