### PR TITLE
fix(server): relax cors origin matching

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -111,6 +111,13 @@ function resolveRequestOrigin(request: Request) {
 	const normalized = normalizeOriginValue(origin);
 	if (!normalized) return null;
 	if (ALLOWED_WEB_ORIGINS.has(normalized)) return normalized;
+	try {
+		const requestOrigin = new URL(request.url).origin;
+		if (normalized === requestOrigin) {
+			return normalized;
+		}
+	} catch {}
+	console.warn("[server] Blocked CORS origin", { origin: normalized });
 	return null;
 }
 


### PR DESCRIPTION
## Summary
- allow CORS when the request origin matches the API’s own origin even if it isn’t configured explicitly
- log blocked origins for visibility

## Testing
- bun check-types --filter=server