### PR TITLE
fix(server): default unknown cors preflight to no-op

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -153,7 +153,7 @@ function handleCorsPreflight(request: Request) {
 	if (!origin) {
 		const headers = new Headers();
 		appendVary(headers, "Origin");
-		return withSecurityHeaders(new Response(null, { status: 403, headers }), request);
+		return withSecurityHeaders(new Response(null, { status: 204, headers }), request);
 	}
 	const headers = new Headers();
 	applyCorsHeaders(headers, request, origin);


### PR DESCRIPTION
## Summary
- respond to unknown-origins preflight with 204 instead of 403 while still logging the blocked origin

## Testing
- bun check-types --filter=server