### PR TITLE
fix(server): fallback to request origin for cors

### DIFF
--- a/apps/server/api/[...path].ts
+++ b/apps/server/api/[...path].ts
@@ -147,8 +147,10 @@ function buildPreflightHeaders(origin: string | null, request: Request) {
 	headers.set("Access-Control-Allow-Methods", ALLOWED_METHODS);
 	headers.set("Access-Control-Allow-Headers", buildAllowedHeaders(request));
 	headers.set("Access-Control-Max-Age", "86400");
-	if (origin) {
-		headers.set("Access-Control-Allow-Origin", origin);
+	const requestedOrigin = request.headers.get("origin");
+	const allowOrigin = origin ?? normalizeOriginValue(requestedOrigin) ?? requestedOrigin;
+	if (allowOrigin) {
+		headers.set("Access-Control-Allow-Origin", allowOrigin);
 		headers.set("Access-Control-Allow-Credentials", "true");
 	}
 	return headers;
@@ -166,8 +168,10 @@ function buildAllowedHeaders(request: Request) {
 }
 
 function applyCorsHeaders(headers: Headers, origin: string | null, request: Request) {
-	if (origin) {
-		headers.set("Access-Control-Allow-Origin", origin);
+	const requestedOrigin = request.headers.get("origin");
+	const allowOrigin = origin ?? normalizeOriginValue(requestedOrigin) ?? requestedOrigin;
+	if (allowOrigin) {
+		headers.set("Access-Control-Allow-Origin", allowOrigin);
 		headers.set("Access-Control-Allow-Credentials", "true");
 		headers.set("Access-Control-Allow-Methods", ALLOWED_METHODS);
 		headers.set("Access-Control-Allow-Headers", buildAllowedHeaders(request));


### PR DESCRIPTION
## Summary
- when a request origin is not explicitly whitelisted, fall back to echoing the incoming `Origin` header so browsers still receive `Access-Control-Allow-Origin`
- apply the same fallback for OPTIONS preflight and normal responses while keeping credentials support and `Vary: Origin`

## Testing
- bun check-types --filter=server