### PR TITLE
fix(server): make serverless handler importable on vercel

### DIFF
--- a/apps/server/api/[...path].ts
+++ b/apps/server/api/[...path].ts
@@ -1,5 +1,5 @@
-export { config } from "./_utils/handler";
-import { handleApiRequest } from "./_utils/handler";
+export { config } from "./_utils/handler.js";
+import { handleApiRequest } from "./_utils/handler.js";
 
 export default {
 	async fetch(request: Request) {

--- a/apps/server/api/auth/get-session.ts
+++ b/apps/server/api/auth/get-session.ts
@@ -1,5 +1,5 @@
-export { config } from "../_utils/handler";
-import { handleApiRequest } from "../_utils/handler";
+export { config } from "../_utils/handler.js";
+import { handleApiRequest } from "../_utils/handler.js";
 
 export default {
 	async fetch(request: Request) {

--- a/apps/server/api/electric/v1/shape.ts
+++ b/apps/server/api/electric/v1/shape.ts
@@ -1,5 +1,5 @@
-export { config } from "../../_utils/handler";
-import { handleApiRequest } from "../../_utils/handler";
+export { config } from "../../_utils/handler.js";
+import { handleApiRequest } from "../../_utils/handler.js";
 
 export default {
 	async fetch(request: Request) {

--- a/apps/server/api/rpc/[...path].ts
+++ b/apps/server/api/rpc/[...path].ts
@@ -1,5 +1,5 @@
-export { config } from "../_utils/handler";
-import { handleApiRequest } from "../_utils/handler";
+export { config } from "../_utils/handler.js";
+import { handleApiRequest } from "../_utils/handler.js";
 
 export default {
 	async fetch(request: Request) {


### PR DESCRIPTION
## Summary
- add `.js` extensions to every serverless route that re-exports the shared handler so Node's ESM loader can resolve `_utils/handler`
- nothing else changes: the handler continues to own the CORS + bundle loading logic, but the imports now work inside Vercel's sandbox

## Testing
- bun run check-types (apps/server)
