### PR TITLE
feat(server): allow guest header bypass

### DIFF
--- a/apps/server/src/lib/context.ts
+++ b/apps/server/src/lib/context.ts
@@ -31,7 +31,11 @@ export async function createContext({ context }: CreateContextOptions) {
 		headerBypassSecret.length === requestBypassSecret.length &&
 		headerBypassSecret.length > 0 &&
 		timingSafeEqual(Buffer.from(headerBypassSecret), Buffer.from(requestBypassSecret));
-	const headerBypassEnabled = devBypassEnabled || envForceBypass || secretMatches;
+	const headerUserId = context.request.headers.get("x-user-id");
+	const allowGuestHeader = (process.env.SERVER_ALLOW_GUEST_HEADER ?? "1") !== "0";
+	const looksLikeGuest = Boolean(headerUserId && headerUserId.toLowerCase().startsWith("guest_"));
+	const headerBypassEnabled =
+		devBypassEnabled || envForceBypass || secretMatches || (allowGuestHeader && looksLikeGuest);
 
 	try {
 		const authSession = await getSessionFromRequest(context.request);

--- a/apps/server/test/context-header-bypass.spec.ts
+++ b/apps/server/test/context-header-bypass.spec.ts
@@ -12,6 +12,7 @@ afterEach(() => {
 	process.env.NODE_ENV = ORIGINAL_NODE_ENV;
 	delete process.env.SERVER_HEADER_BYPASS_SECRET;
 	delete process.env.SERVER_ALLOW_HEADER_BYPASS;
+	delete process.env.SERVER_ALLOW_GUEST_HEADER;
 });
 
 describe("createContext header bypass", () => {
@@ -30,12 +31,12 @@ describe("createContext header bypass", () => {
 		expect(ctx.session?.user.id).toBe("monitor-user");
 	});
 
-	it("rejects header bypass in production when the secret is missing", async () => {
+	it("rejects non-guest header bypass in production when the secret is missing", async () => {
 		process.env.NODE_ENV = "production";
 		process.env.SERVER_HEADER_BYPASS_SECRET = "canary-secret";
 		const request = new Request("https://api.example.com/api/electric/v1/shape", {
 			headers: {
-				"X-User-Id": "monitor-user",
+				"X-User-Id": "member-user",
 			},
 		});
 
@@ -50,12 +51,26 @@ describe("createContext header bypass", () => {
 		const request = new Request("https://api.example.com/api/electric/v1/shape", {
 			headers: {
 				"X-Canary-Secret": "wrong-secret",
-				"X-User-Id": "monitor-user",
+				"X-User-Id": "member-user",
 			},
 		});
 
 		const ctx = await createContext({ context: { request } as any });
 
 		expect(ctx.session).toBeNull();
+	});
+
+	it("allows guest header bypass in production without a secret", async () => {
+		process.env.NODE_ENV = "production";
+		delete process.env.SERVER_HEADER_BYPASS_SECRET;
+		const request = new Request("https://api.example.com/api/electric/v1/shape", {
+			headers: {
+				"X-User-Id": "guest_123abc",
+			},
+		});
+
+		const ctx = await createContext({ context: { request } as any });
+
+		expect(ctx.session?.user.id).toBe("guest_123abc");
 	});
 });

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -7,6 +7,10 @@
 		{
 			"source": "/:path((?!api(?:/|$)).*)",
 			"destination": "/api/:path"
+		},
+		{
+			"source": "/rpc/:path*",
+			"destination": "/api/rpc/:path*"
 		}
 	]
 }

--- a/env.server.example
+++ b/env.server.example
@@ -59,3 +59,5 @@ POSTGRES_WAIT_INTERVAL=2000
 # Allow header-based auth (for production canaries)
 # SERVER_HEADER_BYPASS_SECRET=replace-with-random-secret
 # SERVER_ALLOW_HEADER_BYPASS=0
+# Allow guest header bypass (X-User-Id values that start with guest_)
+# SERVER_ALLOW_GUEST_HEADER=1


### PR DESCRIPTION
## Summary
- allow requests with `X-User-Id: guest_*` to bypass BetterAuth (gated by `SERVER_ALLOW_GUEST_HEADER`, on by default) so Electric and RPC endpoints can work for anonymous users
- retain the timing-safe `X-Canary-Secret` path for canary automation and keep the dev-only fallbacks
- add `/rpc/:path*` rewrite to `vercel.json` so RPC preflights flow through the shared CORS handler
- expand the guest header tests to cover mismatched secrets, guest success, and env cleanup; document the new env in `env.server.example`

## Testing
- bun x vitest run apps/server/test/context-header-bypass.spec.ts
