### PR TITLE
chore(server): log electric error responses

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -426,12 +426,19 @@ async function proxyElectricShape({
 				headers: upstreamHeaders,
 			});
 			if (response.status >= 400) {
+				let errorBody: string | null = null;
+				try {
+					errorBody = await response.text();
+				} catch {}
+				const logPayload = {
+					status: response.status,
+					base,
+					scope,
+					target: target.toString(),
+					message: errorBody?.slice(0, 500) ?? null,
+				};
 				lastError = new Error(`electric responded ${response.status} for ${base}`);
-				if (response.body) {
-					try {
-						await response.body.cancel();
-					} catch {}
-				}
+				console.error("electric.fetch", logPayload);
 				if (candidateIndex < baseCandidates.length - 1 && fallbackDelayMs > 0) {
 					await new Promise((resolve) => setTimeout(resolve, fallbackDelayMs));
 				}


### PR DESCRIPTION
## Summary
- capture Electric's error responses whenever the `/v1/shape` proxy receives `>= 400`, so we know exactly why Electric rejects a request
- log status, scope, base URL, the full target URL, and the first 500 chars of the response body before falling back
- no behavioural change for successful requests; just richer logs to debug the ongoing 400s

## Testing
- not run (log-only change)
