### PR TITLE
fix(ci): update production canary for self-hosted Convex

### DIFF
--- a/.github/workflows/prod-canary.yml
+++ b/.github/workflows/prod-canary.yml
@@ -20,11 +20,8 @@ jobs:
 
       - name: Run canary tests
         env:
-          PROD_SERVER_URL: https://api.osschat.dev
-          PROD_WEB_ORIGIN: https://osschat.dev
+          PROD_CONVEX_URL: ${{ secrets.CONVEX_URL }}
           CANARY_TIMEOUT_MS: "15000"
           CANARY_MAX_RETRIES: "5"
           CANARY_RETRY_DELAY_MS: "10000"
-          CANARY_USER_ID: prod-canary
-          CANARY_SECRET: ${{ secrets.PROD_CANARY_SECRET }}
         run: bun ./scripts/prod-canary.ts


### PR DESCRIPTION
## Summary
- Update production canary to test self-hosted Convex backend instead of deprecated api.osschat.dev
- Fix 404 failures in canary checks by using correct CONVEX_URL from secrets
- Test Convex dashboard, health endpoint, and query API

## Context
The backend was migrated from Bun/Elysia to self-hosted Convex in commit 7c47e68 but the production canary was still testing old endpoints that no longer exist.

## Changes
- `scripts/prod-canary.ts`: Replaced ElectricSQL/old API tests with Convex-specific health checks
- `.github/workflows/prod-canary.yml`: Use `CONVEX_URL` secret instead of hardcoded URLs

## Test plan
- [x] CI will run canary against production Convex deployment
- [x] Canary tests: dashboard, health endpoint, query API

🤖 Generated with [Claude Code](https://claude.com/claude-code)