### PR TITLE
fix(web): wrap useSearchParams in Suspense boundary

### DIFF
--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { Suspense, useEffect, useMemo, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PostHogProvider } from "posthog-js/react";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -10,8 +10,7 @@ import { Toaster } from "sonner";
 import { initPosthog } from "@/lib/posthog";
 import { PosthogBootstrap } from "@/components/posthog-bootstrap";
 
-export default function Providers({ children }: { children: React.ReactNode }) {
-	const queryClient = useMemo(() => new QueryClient(), []);
+function PosthogPageViewTracker() {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	const posthogClient = useMemo(() => initPosthog(), []);
@@ -47,6 +46,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 		previousPathRef.current = `${currentPath || "/"}${search.length > 0 ? `?${search}` : ""}`;
 	}, [entryReferrer, pathname, posthogClient, searchParams]);
 
+	return null;
+}
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+	const queryClient = useMemo(() => new QueryClient(), []);
+	const posthogClient = useMemo(() => initPosthog(), []);
+
 	const appTree = (
 		<ThemeProvider
 			attribute="class"
@@ -57,6 +63,9 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 			<BrandThemeProvider>
 				<QueryClientProvider client={queryClient}>
 					<PosthogBootstrap />
+					<Suspense fallback={null}>
+						<PosthogPageViewTracker />
+					</Suspense>
 					{children}
 					<Toaster richColors position="bottom-right" />
 				</QueryClientProvider>


### PR DESCRIPTION
## Summary
Fix Next.js build failure by wrapping `useSearchParams()` in a Suspense boundary.

## Problem
Production deployment failing with:
```
useSearchParams() should be wrapped in a suspense boundary at page "/404"
Error occurred prerendering page "/_not-found"
Export encountered an error on /_not-found/page
Next.js build worker exited with code: 1
```

Next.js 15.5 requires `useSearchParams()` to be wrapped in Suspense when used in components that are part of statically generated pages (like root layouts).

## Solution
**File:** `apps/web/src/components/providers.tsx`

1. **Extracted PostHog tracking logic** into separate `PosthogPageViewTracker` component
2. **Wrapped in Suspense** with `<Suspense fallback={null}>`
3. **Preserved functionality** - page view tracking still works on client side

```tsx
<Suspense fallback={null}>
  <PosthogPageViewTracker />
</Suspense>
```

This allows Next.js to pre-render pages without the hook, while still tracking page views on the client.

## Test Results
✅ Local build succeeds:
```
✓ Generating static pages (8/8)
✓ Compiled successfully in 14.6s
```

## References
- [Next.js Docs: Missing Suspense with CSR Bailout](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)