### PR TITLE
fix(web): add redirect URI to AuthKit middleware

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,9 @@
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
 
 export default authkitMiddleware({
+	redirectUri: process.env.NEXT_PUBLIC_APP_URL
+		? `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`
+		: `${process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3001"}/auth/callback`,
 	middlewareAuth: {
 		enabled: true,
 		unauthenticatedPaths: ["/", "/auth/:path*", "/api/public/:path*"],


### PR DESCRIPTION
## Summary
Fixes the AuthKit middleware error by adding the required `redirectUri` configuration.

## Issues Fixed
- ✅ `Error: You must provide a redirect URI in the AuthKit middleware or in the environment variables`
- ✅ Cascading `Cannot append headers after they are sent to the client` errors (these were caused by the middleware throwing errors)

## Changes
- Added `redirectUri` configuration to the AuthKit middleware in `apps/web/src/middleware.ts`
- The redirect URI uses:
  1. `NEXT_PUBLIC_APP_URL` (if set) - primary choice
  2. `VERCEL_URL` (for Vercel deployments) - fallback for production
  3. `http://localhost:3001` - fallback for local development

## Test Plan
- [ ] Test authentication flow on local development
- [ ] Verify middleware doesn't throw errors
- [ ] Verify headers are sent correctly
- [ ] Test on Vercel deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)