### PR TITLE
fix(web): add required WorkOS environment variables to .env.example

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,6 +2,14 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3001
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
+# WorkOS AuthKit Configuration
+# Get these from https://dashboard.workos.com/
+WORKOS_CLIENT_ID=client_YOUR_CLIENT_ID_HERE
+WORKOS_API_KEY=sk_test_YOUR_API_KEY_HERE
+# Generate with: openssl rand -base64 48
+WORKOS_COOKIE_PASSWORD=CHANGE_ME_TO_AT_LEAST_32_CHARACTERS_USE_OPENSSL_RAND_BASE64_48
+WORKOS_REDIRECT_URI=http://localhost:3001/auth/callback
+
 # Optional Electric SQL sync service
 NEXT_PUBLIC_ELECTRIC_URL=http://localhost:3010
 NEXT_PUBLIC_ELECTRIC_WORKSPACE_TTL_MS=600000


### PR DESCRIPTION
## Summary
Adds all required WorkOS AuthKit environment variables to `.env.example` to prevent runtime configuration errors.

## Issues Fixed
- ✅ `Error: You must provide a valid cookie password that is at least 32 characters in the environment variables`
- ✅ Missing WorkOS configuration documentation

## Changes
Added to `apps/web/.env.example`:
- `WORKOS_CLIENT_ID`: Client identifier from WorkOS dashboard
- `WORKOS_API_KEY`: API key for server-side authentication operations
- `WORKOS_COOKIE_PASSWORD`: Secure password for session cookie encryption (must be 32+ chars)
- `WORKOS_REDIRECT_URI`: OAuth callback URL (defaults to `/auth/callback`)

## Documentation
- Includes link to WorkOS dashboard for obtaining credentials
- Provides command to generate secure cookie password: `openssl rand -base64 48`
- Clear placeholder values that won't be mistaken for real credentials

## Test Plan
- [ ] Copy `.env.example` to `.env.local`
- [ ] Fill in real WorkOS credentials
- [ ] Generate cookie password with provided command
- [ ] Verify app starts without environment variable errors
- [ ] Test authentication flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)