### PR TITLE
fix: simplify .env.example to focus on Convex as primary backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,25 +2,23 @@
 # OpenChat Environment Configuration
 # ==============================================================================
 # Copy this file to .env.local and fill in your values
-# Generate secrets with: openssl rand -base64 32
 
 # ==============================================================================
 # REQUIRED: Authentication
 # ==============================================================================
-# better-auth secret for session encryption (REQUIRED in production)
+# better-auth secret for session encryption
 # Generate with: openssl rand -base64 32
 BETTER_AUTH_SECRET=CHANGE_ME_USE_OPENSSL_RAND_BASE64_32
 
 # ==============================================================================
-# REQUIRED: Database (Production)
+# REQUIRED: Convex (Backend Database & Realtime Sync)
 # ==============================================================================
-# PostgreSQL connection string (REQUIRED in production)
-# Development: Can use in-memory fallback if not set
-# Production: MUST be set
-DATABASE_URL=postgresql://user:password@host:5432/openchat
+# Get these from: bunx convex dev (local) or your Convex dashboard (production)
+CONVEX_URL=http://localhost:3210
+NEXT_PUBLIC_CONVEX_URL=http://localhost:3210
 
 # ==============================================================================
-# Public URLs
+# REQUIRED: Public URLs
 # ==============================================================================
 # Web app URL (frontend)
 NEXT_PUBLIC_APP_URL=http://localhost:3001
@@ -29,23 +27,18 @@ NEXT_PUBLIC_APP_URL=http://localhost:3001
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
 # ==============================================================================
-# Optional: Advanced Configuration
+# Optional: PostgreSQL for Auth Sessions
 # ==============================================================================
-# Server-to-server internal URL (optional)
-# Use this if your server needs to call itself via a different URL
-# SERVER_INTERNAL_URL=http://localhost:3000
-
-# better-auth base URL (optional, defaults to SERVER_INTERNAL_URL or NEXT_PUBLIC_SERVER_URL)
-# BETTER_AUTH_URL=http://localhost:3000
-
-# Cross-subdomain cookie domain (optional, for sharing auth between subdomains)
-# AUTH_COOKIE_DOMAIN=.yourdomain.com
+# If not set, auth uses in-memory storage (dev only - sessions reset on restart)
+# For production with persistent sessions, provide a PostgreSQL connection string
+# DATABASE_URL=postgresql://user:password@host:5432/openchat
 
 # ==============================================================================
-# Convex (Backend sync - replaces ElectricSQL)
+# Optional: Convex Deployment (Production)
 # ==============================================================================
-CONVEX_URL=http://localhost:3210
-NEXT_PUBLIC_CONVEX_URL=http://localhost:3210
+# For production deployments to Convex
+# CONVEX_DEPLOYMENT=prod:your-deployment-name
+# CONVEX_ADMIN_URL=https://your-project.convex.cloud
 
 # ==============================================================================
 # Optional: Analytics (PostHog)
@@ -54,6 +47,18 @@ NEXT_PUBLIC_CONVEX_URL=http://localhost:3210
 # NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # POSTHOG_API_KEY=your_server_key
 # POSTHOG_HOST=https://us.i.posthog.com
+
+# ==============================================================================
+# Optional: Advanced Configuration
+# ==============================================================================
+# Server-to-server internal URL (optional)
+# SERVER_INTERNAL_URL=http://localhost:3000
+
+# better-auth base URL (optional, defaults to SERVER_INTERNAL_URL or NEXT_PUBLIC_SERVER_URL)
+# BETTER_AUTH_URL=http://localhost:3000
+
+# Cross-subdomain cookie domain (optional, for sharing auth between subdomains)
+# AUTH_COOKIE_DOMAIN=.yourdomain.com
 
 # ==============================================================================
 # Development Only: Auth Bypass


### PR DESCRIPTION
## Summary

Simplifies and clarifies the  to reflect the actual architecture:

- **Convex** is the primary backend (REQUIRED)
- **PostgreSQL** is optional for auth sessions (uses memory fallback in dev)
- Removed confusing emphasis on PostgreSQL/ElectricSQL

## Changes

- ✅ Made DATABASE_URL optional with clear explanation
- ✅ Highlighted Convex as the required backend
- ✅ Added instructions for `bunx convex dev`
- ✅ Cleaned up structure and comments
- ✅ Removed ElectricSQL references
- ✅ Better organized into REQUIRED vs Optional sections

## Architecture

- **Convex**: Stores users, chats, messages (primary data)
- **better-auth**: Handles authentication (can use memory fallback or PostgreSQL)

## For Production

Set these in Dokploy:
```bash
BETTER_AUTH_SECRET=<generated secret>
CONVEX_URL=<your convex deployment url>
NEXT_PUBLIC_CONVEX_URL=<your convex deployment url>
NEXT_PUBLIC_APP_URL=https://osschat.dev
NEXT_PUBLIC_SERVER_URL=https://osschat.dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)