### PR TITLE
fix: make CONVEX_SELF_HOSTED_ADMIN_KEY optional for docker compose validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - ./convex.json:/app/convex.json:ro
     environment:
       CONVEX_SELF_HOSTED_URL: ${CONVEX_SELF_HOSTED_URL:-http://backend:3210}
-      CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:?CONVEX_SELF_HOSTED_ADMIN_KEY is required}
+      CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:-}
     command: ["bun", "x", "convex", "deploy", "--yes"]
     depends_on:
       backend:


### PR DESCRIPTION
## Summary
Made `CONVEX_SELF_HOSTED_ADMIN_KEY` optional in docker-compose.yml to fix Dokploy deployment validation error.

## Problem
Dokploy deployment failed with:
```
error while interpolating services.deploy.environment.CONVEX_SELF_HOSTED_ADMIN_KEY: 
required variable CONVEX_SELF_HOSTED_ADMIN_KEY is missing a value
```

The issue: Docker Compose validates ALL services' environment variables during `docker compose up`, even services in profiles that won't run. The `deploy` service has `profiles: [tools]` so it doesn't run during normal startup, but the validation still happens.

## The Chicken-and-Egg Problem

1. Can't generate admin key until backend is running
2. Can't start backend if validation fails due to missing admin key
3. Deploy service needs admin key, but it's in a profile so it shouldn't block startup

## Solution

Changed from `:?` (required) to `:-` (optional with empty default):

```yaml
# Before
CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:?CONVEX_SELF_HOSTED_ADMIN_KEY is required}

# After  
CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:-}
```

This allows `docker compose up` validation to pass, while the Convex CLI will still give a clear auth error if you actually try to run deploy without the key.

## Deployment Flow (Still Required!)

The deploy service is still REQUIRED for the website to work:

```bash
# 1. Start backend (no admin key needed for validation)
docker compose up -d backend dashboard

# 2. Generate admin key
docker compose exec backend ./generate_admin_key.sh

# 3. Add to environment
CONVEX_SELF_HOSTED_ADMIN_KEY=admin_xxxxx

# 4. Deploy functions (REQUIRED!)
docker compose run --rm deploy

# 5. Start web
docker compose up -d web
```

Without step 4, the web app will fail because no functions are deployed to the backend.

## Test Plan
- [ ] Verify `docker compose up -d backend` succeeds without admin key
- [ ] Generate admin key from running backend
- [ ] Verify `docker compose run --rm deploy` fails with clear error if no admin key
- [ ] Verify `docker compose run --rm deploy` succeeds with admin key set
- [ ] Verify web app works after functions are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)