### PR TITLE
fix: configure Convex backend for two-domain setup with correct HTTP origins

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -73,15 +73,19 @@ CONVEX_SELF_HOSTED_ADMIN_KEY=<from_generate_admin_key.sh>
 # CONVEX_URL: Used by Next.js server to reach backend (Docker internal network)
 #   - Must be http://backend:3210 (NOT https://, backend is the service name)
 #
-# NEXT_PUBLIC_CONVEX_URL: Used by browser to reach backend (public internet)
-#   - Must be https://api.yourdomain.com (your public backend URL with reverse proxy)
+# NEXT_PUBLIC_CONVEX_URL: Used by browser for database/WebSocket (port 3210)
+#   - Must be https://api.yourdomain.com (your public backend URL)
+#
+# NEXT_PUBLIC_CONVEX_SITE_URL: Used by browser for HTTP API/auth (port 3211)
+#   - Must be https://site.yourdomain.com (your public HTTP API URL)
 
 # Convex Backend URLs
 CONVEX_URL=http://backend:3210
 NEXT_PUBLIC_CONVEX_URL=https://api.osschat.dev
+NEXT_PUBLIC_CONVEX_SITE_URL=https://site.osschat.dev
 CONVEX_SELF_HOSTED_URL=http://backend:3210
 CONVEX_CLOUD_ORIGIN=https://api.osschat.dev
-CONVEX_SITE_ORIGIN=https://api.osschat.dev
+CONVEX_SITE_ORIGIN=https://site.osschat.dev
 
 # Public URLs (replace with your domains)
 NEXT_PUBLIC_APP_URL=https://osschat.dev
@@ -92,13 +96,23 @@ SITE_URL=https://osschat.dev
 
 ### Reverse Proxy Configuration
 
-You need to configure reverse proxies in Dokploy for:
+**IMPORTANT**: Convex self-hosted uses TWO separate ports that both need public URLs:
+- **Port 3210**: Database/WebSocket
+- **Port 3211**: HTTP API (auth routes)
 
-1. **Backend API** (`api.osschat.dev` → port 3210)
-2. **Dashboard** (`dash.osschat.dev` → port 6790)
-3. **Web App** (`osschat.dev` → port 3001)
+Configure these domains in Dokploy:
 
-In Dokploy, go to your service settings and add these domains with their corresponding ports.
+1. **Backend Database** (`api.osschat.dev` → port 3210)
+2. **Backend HTTP/Auth** (`site.osschat.dev` → port 3211) ⚠️ **REQUIRED for auth!**
+3. **Dashboard** (`dash.osschat.dev` → port 6790)
+4. **Web App** (`osschat.dev` → port 3001)
+
+In Dokploy:
+1. Go to your backend service → Domains section
+2. Add TWO domains:
+   - `api.osschat.dev` with target port `3210`
+   - `site.osschat.dev` with target port `3211`
+3. Add dashboard and web domains to their respective services
 
 ### Deployment Steps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
       - convex-data:/convex/data
     environment:
       INSTANCE_NAME: ${INSTANCE_NAME:-openchat-backend}
+      # Public URL for database/WebSocket (port 3210)
       CONVEX_CLOUD_ORIGIN: ${CONVEX_CLOUD_ORIGIN:-http://localhost:3210}
+      # Public URL for HTTP API (port 3211) - REQUIRED for HTTP actions!
       CONVEX_SITE_ORIGIN: ${CONVEX_SITE_ORIGIN:-http://localhost:3211}
     networks:
       default:
@@ -29,7 +31,8 @@ services:
     ports:
       - "6790:6791"
     environment:
-      NEXT_PUBLIC_DEPLOYMENT_URL: ${NEXT_PUBLIC_CONVEX_URL:-http://localhost:3210}
+      # Dashboard needs database URL (port 3210), not HTTP URL
+      NEXT_PUBLIC_DEPLOYMENT_URL: ${CONVEX_CLOUD_ORIGIN:-http://localhost:3210}
     depends_on:
       backend:
         condition: service_healthy
@@ -57,7 +60,7 @@ services:
       dockerfile: docker/web.Dockerfile
       args:
         NEXT_PUBLIC_CONVEX_URL: ${NEXT_PUBLIC_CONVEX_URL:-http://localhost:3210}
-        NEXT_PUBLIC_CONVEX_SITE_URL: ${NEXT_PUBLIC_CONVEX_URL:-http://localhost:3210}
+        NEXT_PUBLIC_CONVEX_SITE_URL: ${NEXT_PUBLIC_CONVEX_SITE_URL:-http://localhost:3211}
         NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3001}
         NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3001}
         NEXT_PUBLIC_SERVER_URL: ${NEXT_PUBLIC_SERVER_URL:-http://localhost:3000}
@@ -68,7 +71,7 @@ services:
       SITE_URL: ${SITE_URL:-http://localhost:3001}
       CONVEX_URL: ${CONVEX_URL:-http://backend:3210}
       NEXT_PUBLIC_CONVEX_URL: ${NEXT_PUBLIC_CONVEX_URL:-http://localhost:3210}
-      NEXT_PUBLIC_CONVEX_SITE_URL: ${NEXT_PUBLIC_CONVEX_URL:-http://localhost:3210}
+      NEXT_PUBLIC_CONVEX_SITE_URL: ${NEXT_PUBLIC_CONVEX_SITE_URL:-http://localhost:3211}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-}
       NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-}
       NEXT_PUBLIC_WEB_URL: ${NEXT_PUBLIC_WEB_URL:-}


### PR DESCRIPTION
## Summary
- ✅ Fixes "HTTP actions not enabled" error on production backend
- ✅ Fixes dashboard "Bad Gateway" by using correct environment variables
- ✅ Corrects NEXT_PUBLIC_CONVEX_SITE_URL defaults to use port 3211
- ✅ Fixes production environment variables documentation
- ✅ Updates documentation for two-domain production setup

## Root Cause
Convex self-hosted backend requires TWO public URLs to be configured:
1. **Port 3210** (Database/WebSocket) via `CONVEX_CLOUD_ORIGIN`
2. **Port 3211** (HTTP API/auth routes) via `CONVEX_SITE_ORIGIN`

Without these properly configured, the backend doesn't enable HTTP actions, resulting in:
- "HTTP actions not enabled" error when accessing the backend
- Dashboard "Bad Gateway" errors
- Auth endpoints returning 403/404

## Changes Made

### docker-compose.yml
1. **Backend service**: Added environment variables with clear comments:
   - `CONVEX_CLOUD_ORIGIN` for port 3210 (database)
   - `CONVEX_SITE_ORIGIN` for port 3211 (HTTP API)

2. **Dashboard service**: Changed from `NEXT_PUBLIC_CONVEX_URL` to `CONVEX_CLOUD_ORIGIN`

3. **Web service**: Fixed `NEXT_PUBLIC_CONVEX_SITE_URL` defaults:
   - Build args: Now defaults to `http://localhost:3211` (was incorrectly `3210`)
   - Runtime env: Now defaults to `http://localhost:3211` (was incorrectly `3210`)

### SELF_HOSTING.md
- **Fixed production environment variables**:
  - Added missing `NEXT_PUBLIC_CONVEX_SITE_URL=https://site.osschat.dev`
  - Corrected `CONVEX_SITE_ORIGIN` from `https://api.osschat.dev` → `https://site.osschat.dev`
  - Added comments explaining the purpose of each URL
- **Updated reverse proxy configuration**:
  - Clarified that Convex needs TWO separate domain mappings in production
  - Added step-by-step Dokploy domain configuration instructions
  - Documented the purpose of each port (3210 vs 3211)

## Production Setup Required

After merging, configure TWO domains in Dokploy for the backend service:

1. **api.osschat.dev** → port 3210 (database/WebSocket)
2. **site.osschat.dev** → port 3211 (HTTP API/auth)

Then update these environment variables in Dokploy:
```env
CONVEX_CLOUD_ORIGIN=https://api.osschat.dev
CONVEX_SITE_ORIGIN=https://site.osschat.dev
NEXT_PUBLIC_CONVEX_URL=https://api.osschat.dev
NEXT_PUBLIC_CONVEX_SITE_URL=https://site.osschat.dev
```

## Test Plan
- [ ] Local: `docker compose down && docker compose up -d` should work with localhost defaults
- [ ] Production: Backend should enable HTTP actions after setting env vars
- [ ] Production: Dashboard should connect successfully
- [ ] Production: Auth endpoints should return 200 OK

## Notes
- Supersedes PR #160 (closed due to branch protection rules)
- All critical issues from AI review have been addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)