### PR TITLE
fix: properly validate better-auth sessions on server side

### DIFF
--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -19,14 +19,21 @@ export default function LoginPage() {
 		setLoading(true);
 
 		try {
-			await authClient.signIn.email({
+			const result = await authClient.signIn.email({
 				email,
 				password,
 			});
-			router.push("/dashboard");
+
+			if (result.error) {
+				setError(result.error.message || "Failed to sign in");
+				setLoading(false);
+				return;
+			}
+
+			// Force reload to clear any cached auth state
+			window.location.href = "/dashboard";
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to sign in");
-		} finally {
 			setLoading(false);
 		}
 	};

--- a/apps/web/src/lib/auth-server.ts
+++ b/apps/web/src/lib/auth-server.ts
@@ -9,24 +9,48 @@ export type UserContext = {
 	image?: string | null;
 };
 
-// Simple session parsing from cookies
-// In production, this should validate the JWT/session token properly
+// Get session from better-auth API
 const resolveUserContext = cache(async (): Promise<UserContext> => {
 	const cookieStore = await cookies();
-	const sessionCookie = cookieStore.get("openchat.session-token") || cookieStore.get("openchat-session-token");
 
-	if (!sessionCookie) {
+	// better-auth stores session token with the cookiePrefix from convex/auth.ts
+	// Default is "openchat" so cookie is "openchat.session-token"
+	const sessionToken = cookieStore.get("openchat.session-token")?.value;
+
+	if (!sessionToken) {
 		redirect("/auth/sign-in");
 	}
 
-	// For now, return a placeholder
-	// TODO: Properly decode and validate the session token
-	return {
-		userId: "placeholder-id",
-		email: "user@example.com",
-		name: "User",
-		image: null,
-	};
+	// Call better-auth API to get session
+	try {
+		const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.SITE_URL || "http://localhost:3001";
+		const response = await fetch(`${baseUrl}/api/auth/get-session`, {
+			headers: {
+				Cookie: `openchat.session-token=${sessionToken}`,
+			},
+			cache: "no-store",
+		});
+
+		if (!response.ok) {
+			redirect("/auth/sign-in");
+		}
+
+		const data = await response.json();
+
+		if (!data.user) {
+			redirect("/auth/sign-in");
+		}
+
+		return {
+			userId: data.user.id,
+			email: data.user.email,
+			name: data.user.name,
+			image: data.user.image,
+		};
+	} catch (error) {
+		console.error("Failed to get session:", error);
+		redirect("/auth/sign-in");
+	}
 });
 
 export async function getUserContext(): Promise<UserContext> {


### PR DESCRIPTION
## Summary
Fixed authentication flow where login succeeded but dashboard kept redirecting back to login page.

## Problem
- `auth-server.ts` had placeholder implementation that didn't validate real sessions
- Login would set cookies but server-side didn't recognize them
- Dashboard would always redirect to `/auth/sign-in`

## Solution
✅ **Updated auth-server.ts**:
- Now calls `/api/auth/get-session` to validate session tokens
- Uses correct cookie name: `openchat.session-token` (matches better-auth cookiePrefix)
- Returns real user data from better-auth instead of placeholders

✅ **Fixed login redirect**:
- Changed from `router.push()` to `window.location.href` for hard navigation
- Clears any cached auth state on client
- Added proper error handling

## Flow Now
1. User submits login form → better-auth creates session
2. Cookie `openchat.session-token` is set
3. Redirect to `/dashboard` with hard reload
4. Server reads cookie and validates via `/api/auth/get-session`
5. Returns real user data
6. Dashboard renders successfully

## Testing
- [ ] Login and verify redirect to dashboard works
- [ ] Refresh dashboard page and verify stays logged in
- [ ] Logout and verify redirect to login
- [ ] Direct access to /dashboard without login redirects to /auth/sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)