### PR TITLE
fix: remove deprecated instrumentationHook and add onRequestError

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,7 +4,6 @@ import { withSentryConfig } from "@sentry/nextjs";
 const nextConfig = {
 	experimental: {
 		externalDir: true,
-		instrumentationHook: true,
 	},
 	typedRoutes: true,
 	output: "standalone",

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
 		await import("./sentry.server.config");
@@ -7,3 +9,5 @@ export async function register() {
 		await import("./sentry.edge.config");
 	}
 }
+
+export const onRequestError = Sentry.captureRequestError;


### PR DESCRIPTION
Fixes Next.js 15 build warnings for Sentry.

## Changes
- Removed  from experimental flags (deprecated in Next.js 15)
- Added  hook to capture nested React Server Component errors

## Warnings Fixed
- ⚠️  is no longer needed
- ⚠️ Could not find  hook in instrumentation file

Build will now be cleaner without warnings.