### PR TITLE
fix: optimize Docker build to prevent timeouts in Dokploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 test-results/
 tmp/
 packages/auth/dist/
+.dmux/

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -19,6 +19,12 @@ ENV NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}
 ENV NEXT_PUBLIC_SERVER_URL=${NEXT_PUBLIC_SERVER_URL}
 ENV NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
 ENV NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+# Disable Sentry source map upload during Docker build (saves time/memory)
+ENV SENTRY_UPLOAD_DRY_RUN=true
+# Disable Next.js telemetry
+ENV NEXT_TELEMETRY_DISABLED=1
+# Increase Node.js memory limit for build
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN bun run --cwd apps/web build
 
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## Summary
Fixes random build cancellations in Dokploy by optimizing resource usage during Docker builds.

## Changes
- Add SENTRY_UPLOAD_DRY_RUN=true to skip source map upload during build
- Add NEXT_TELEMETRY_DISABLED=1 to disable telemetry  
- Set NODE_OPTIONS max heap to 4GB to prevent OOM
- Add .dmux/ to .gitignore

## Impact
Should resolve build cancellations during Next.js optimization phase in Dokploy.