### PR TITLE
fix(ui): resolve textarea flash, model selector overflow, and mobile spacing

### DIFF
--- a/apps/web/src/components/chat-composer.tsx
+++ b/apps/web/src/components/chat-composer.tsx
@@ -11,26 +11,27 @@ type UseAutoResizeTextareaProps = { minHeight: number; maxHeight?: number };
 function useAutoResizeTextarea({ minHeight, maxHeight }: UseAutoResizeTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const adjustHeight = useCallback(
-    (reset?: boolean) => {
-      const textarea = textareaRef.current;
-      if (!textarea) return;
+	const adjustHeight = useCallback(
+		(reset?: boolean) => {
+			const textarea = textareaRef.current;
+			if (!textarea) return;
 
-      if (reset) {
-        textarea.style.height = `${minHeight}px`;
-        return;
-      }
+			if (reset) {
+				textarea.style.height = `${minHeight}px`;
+				return;
+			}
 
-      textarea.style.height = `${minHeight}px`;
-      const newHeight = Math.max(
-        minHeight,
-        Math.min(textarea.scrollHeight, maxHeight ?? Number.POSITIVE_INFINITY),
-      );
+			// Calculate new height without resetting first to prevent flash
+			const currentHeight = textarea.scrollHeight;
+			const newHeight = Math.max(
+				minHeight,
+				Math.min(currentHeight, maxHeight ?? Number.POSITIVE_INFINITY),
+			);
 
-      textarea.style.height = `${newHeight}px`;
-    },
-    [minHeight, maxHeight],
-  );
+			textarea.style.height = `${newHeight}px`;
+		},
+		[minHeight, maxHeight],
+	);
 
   useEffect(() => {
     const textarea = textareaRef.current;

--- a/apps/web/src/components/chat-room.tsx
+++ b/apps/web/src/components/chat-room.tsx
@@ -564,7 +564,7 @@ export default function ChatRoom({ chatId, initialMessages }: ChatRoomProps) {
         className="flex-1 rounded-xl bg-background/40 shadow-inner overflow-hidden"
       />
 
-      <div className="pointer-events-none fixed bottom-4 left-4 right-4 z-30 flex justify-center transition-all duration-300 ease-in-out md:left-[calc(var(--sb-width)+1.5rem)] md:right-6">
+      <div className="pointer-events-none fixed bottom-4 left-6 right-6 z-30 flex justify-center transition-all duration-300 ease-in-out md:left-[calc(var(--sb-width)+1.5rem)] md:right-6">
         <div ref={composerRef} className="pointer-events-auto w-full max-w-3xl">
 			<ChatComposer
 				placeholder="Ask OpenChat a question..."

--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -132,14 +132,14 @@ export function ModelSelector({ options, value, onChange, disabled, loading }: M
 					disabled={disabled || loading || options.length === 0}
 					role="combobox"
 					aria-expanded={open}
-					title={triggerTitle}
+					title={triggerTitle ?? triggerLabel}
 					className="flex h-10 min-w-[220px] max-w-[360px] items-center justify-between gap-2 rounded-xl bg-background/90 px-3 text-left text-foreground"
 				>
 					<span className="flex min-w-0 items-center gap-2">
 						<span className="bg-muted text-muted-foreground/90 flex size-8 items-center justify-center rounded-lg">
 							<OptionGlyph option={selectedOption} />
 						</span>
-						<span className="text-sm font-medium leading-tight text-left whitespace-normal">{triggerLabel}</span>
+						<span className="truncate text-sm font-medium leading-tight text-left">{triggerLabel}</span>
 					</span>
 					<ChevronDown className={cn("size-4 transition-transform", open ? "rotate-180" : "rotate-0", disabled ? "opacity-40" : "opacity-60")} />
 				</Button>


### PR DESCRIPTION
## Summary

- Fix textarea auto-resize flash by avoiding height reset before calculation
- Fix model selector label overflow with proper truncation and hover tooltip
- Standardize mobile horizontal spacing to match design system (24px)

## Changes

### Textarea Auto-Resize Flash (chat-composer.tsx)
**Problem:** The textarea would visibly flash/jump when typing because it reset to minHeight before calculating the new height.

**Solution:** Calculate new height directly from scrollHeight without resetting first, eliminating the visual flash.

### Model Selector Label Overflow (model-selector.tsx)
**Problem:** Long model names would wrap to multiple lines using whitespace-normal, breaking the button layout.

**Solution:** 
- Use truncate class to prevent wrapping and add ellipsis
- Add fallback title attribute (uses full label when no additional info) for accessibility

### Mobile Spacing Consistency (chat-room.tsx)
**Problem:** Chat composer used left-4 right-4 (16px) on mobile while hero section and other components use px-6 (24px).

**Solution:** Changed to left-6 right-6 to match the established 24px horizontal padding pattern across the app.

## Testing
- TypeScript type check passed
- Linting passed (oxlint)
- No breaking changes to existing functionality

## Files Changed
- apps/web/src/components/chat-composer.tsx - Fixed textarea flash
- apps/web/src/components/model-selector.tsx - Fixed label overflow + added tooltip
- apps/web/src/components/chat-room.tsx - Standardized mobile spacing