### PR TITLE
fix: remove signup route reference

### DIFF
--- a/apps/web/src/components/dashboard-access-fallback.tsx
+++ b/apps/web/src/components/dashboard-access-fallback.tsx
@@ -28,12 +28,6 @@ export default function DashboardAccessFallback({
 				>
 					Sign in
 				</Link>
-				<Link
-					href="/auth/sign-up"
-					className={cn(buttonVariants({ variant: "outline", size: "lg" }))}
-				>
-					Create account
-				</Link>
 				{showHomeLink ? (
 					<Link
 						href="/"


### PR DESCRIPTION
## Problem
Build failing in Dokploy with TypeScript error:
```
Type error: "/auth/sign-up" is not an existing route
```

## Cause
During OAuth migration (PR #170), we removed the `/auth/sign-up` page but forgot to update `dashboard-access-fallback.tsx` which still had a "Create account" button linking to it.

## Fix
- Remove the "Create account" button
- OAuth providers (GitHub/Google) handle both login and signup in one flow
- Only "Sign in" button needed now

## Testing
✅ Build tested locally - passes TypeScript validation
✅ No other references to `/auth/sign-up` found in codebase