### PR TITLE
fix(types): replace any types and remove ts-ignore comments

### DIFF
--- a/apps/server/convex/auth.ts
+++ b/apps/server/convex/auth.ts
@@ -8,7 +8,7 @@ import { query } from "./_generated/server";
 
 const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
 
-// @ts-ignore - betterAuth component is registered via convex.config.ts
+// betterAuth component is registered via convex.config.ts and properly typed in _generated/api.d.ts
 export const authComponent = createClient<DataModel>(components.betterAuth);
 
 export const createAuth = (
@@ -64,7 +64,8 @@ export const createAuth = (
 export const getCurrentUser = query({
 	args: {},
 	handler: async (ctx) => {
-		// @ts-ignore - authComponent expects GenericCtx but query provides QueryCtx
+		// QueryCtx is compatible with GenericCtx at runtime - the types are structurally compatible
+		// @ts-expect-error - authComponent.getAuthUser expects GenericCtx but query provides QueryCtx which has a compatible structure
 		return authComponent.getAuthUser(ctx);
 	},
 });

--- a/apps/web/src/app/api/chat/chat-handler.ts
+++ b/apps/web/src/app/api/chat/chat-handler.ts
@@ -53,6 +53,14 @@ type StreamPersistRequest = {
 	status: "streaming" | "completed";
 };
 
+type ChatRequestPayload = {
+	modelId?: string;
+	apiKey?: string;
+	chatId?: string;
+	messages?: unknown[];
+	assistantMessageId?: string;
+};
+
 function clampUserText(message: AnyUIMessage): AnyUIMessage {
 	if (message.role !== "user") return message;
 	let remaining = MAX_USER_PART_CHARS;
@@ -142,7 +150,7 @@ export type ChatHandlerOptions = {
 	persistMessage?: (input: StreamPersistRequest) => Promise<{ ok: boolean }>;
 	resolveModel?: (input: {
 		request: Request;
-		payload: any;
+		payload: ChatRequestPayload;
 	}) => Promise<{ provider: ReturnType<typeof createOpenRouter>; modelId: string }>;
 };
 
@@ -245,7 +253,7 @@ export function createChatHandler(options: ChatHandlerOptions = {}) {
 			return new Response("Too Many Requests", { status: 429, headers });
 		}
 
-		let payload: any;
+		let payload: ChatRequestPayload;
 		try {
 			payload = await request.json();
 		} catch {


### PR DESCRIPTION
## Summary
- Define proper TypeScript interfaces for chat handler payloads to replace unsafe any types
- Remove @ts-ignore comments and replace with @ts-expect-error with clear explanations where needed
- Improve type safety across the codebase without changing runtime behavior