### PR TITLE
perf(backend): add cache limits, pagination, and optimize queries

### DIFF
--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -11,8 +11,8 @@ export async function GET() {
 		name: session.name,
 		image: session.image,
 	});
-	const chats = await listChats(userId);
-	return NextResponse.json({ chats: chats.map(serializeChat) });
+	const result = await listChats(userId);
+	return NextResponse.json({ chats: result.chats.map(serializeChat), nextCursor: result.nextCursor });
 }
 
 export async function POST(request: Request) {

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ export default async function DashboardLayout({ children }: { children: ReactNod
 		name: session.name,
 		image: session.image,
 	});
-	const rawChats = await listChats(convexUserId);
+	const { chats: rawChats } = await listChats(convexUserId);
 	const chats = rawChats.map((chat) => ({
 		id: chat._id,
 		title: chat.title,

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -353,7 +353,17 @@ function ChatList({
 	);
 }
 
+// Memoization cache for sortChats
+const sortChatsCache = new WeakMap<ChatListItem[], ChatListItem[]>();
+let sortChatsCacheKey: ChatListItem[] | null = null;
+let sortChatsCacheResult: ChatListItem[] | null = null;
+
 function sortChats(list: ChatListItem[]) {
+	// Check if we have a cached result for this exact array reference
+	if (sortChatsCacheKey === list && sortChatsCacheResult) {
+		return sortChatsCacheResult;
+	}
+	
 	const copy = list.map(ensureNormalizedChat);
 	copy.sort((a, b) => {
 		const aLast = a.lastActivityMs ?? 0;
@@ -364,5 +374,10 @@ function sortChats(list: ChatListItem[]) {
 		if (bUp !== aUp) return bUp - aUp;
 		return a.id.localeCompare(b.id);
 	});
+	
+	// Cache the result
+	sortChatsCacheKey = list;
+	sortChatsCacheResult = copy;
+	
 	return copy;
 }


### PR DESCRIPTION
## Summary
- Add TTL and size limits to chat prefetch cache
- Implement cursor-based pagination for chat list
- Memoize expensive sort operations in sidebar
- Eliminate duplicate session fetches