### PR TITLE
fix: exclude test files from production build type checking

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -42,6 +42,11 @@
 		".next/types/**/*.ts"
 	],
 	"exclude": [
-		"./node_modules"
+		"./node_modules",
+		"./test",
+		"./**/*.spec.ts",
+		"./**/*.spec.tsx",
+		"./**/*.test.ts",
+		"./**/*.test.tsx"
 	]
 }


### PR DESCRIPTION
## Problem
Build getting stuck/cancelled during "Linting and checking validity of types" phase in Dokploy.

## Root Cause
Test files (*.spec.ts, *.test.tsx) were being type-checked during production builds, causing:
- Type errors from test-only dependencies (happy-dom incompatible types)
- Increased build time and memory usage
- Build timeouts in resource-constrained environments

## Fix
Updated `apps/web/tsconfig.json` to exclude:
- `./test` directory
- `**/*.spec.ts` and `**/*.spec.tsx`
- `**/*.test.ts` and `**/*.test.tsx`

## Impact
- ✅ Faster builds (less files to type-check)
- ✅ Lower memory usage
- ✅ No type errors from test files
- ✅ Tests still run normally with their own config

## Testing
✅ Production build completes successfully in ~43s locally