### PR TITLE
fix(database): add indexes, validation, and soft delete

### DIFF
--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -27,9 +27,9 @@ export default defineSchema({
 		createdAt: v.number(),
 		status: v.optional(v.string()),
 		userId: v.optional(v.id("users")),
+		deletedAt: v.optional(v.number()),
 	})
 		.index("by_chat", ["chatId", "createdAt"])
 		.index("by_client_id", ["chatId", "clientMessageId"])
-		.index("by_user", ["userId"])
-		.index("unique_client_message", ["chatId", "clientMessageId"]),
+		.index("by_user", ["userId"]),
 });


### PR DESCRIPTION
## Summary
- Add critical database indexes (userId on messages) and message content validation (100KB max in bytes)
- Implement soft delete for chats and messages to enable data recovery and prevent accidental data loss
- Properly populate userId field in messages for query optimization
- Use byte count instead of string length for content validation

## Changes
- Added userId index to messages table for better query performance
- Added message content length validation using actual byte count (100KB max)
- Added deletedAt field to both chats and messages tables
- Implemented soft delete with cascade for messages when parent chat is deleted
- All queries now filter out soft-deleted records
- userId field is properly populated during message insert/update operations