### PR TITLE
fix: remove baseURL from auth client

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -2,12 +2,7 @@ import { createAuthClient } from "better-auth/react";
 import { convexClient } from "@convex-dev/better-auth/client/plugins";
 import { lastLoginMethodClient } from "better-auth/client/plugins";
 
-// Configure client with proper base URL for API routes
-const baseURL = typeof window !== 'undefined' 
-	? window.location.origin 
-	: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001';
-
+// The convexClient plugin handles routing automatically
 export const authClient = createAuthClient({
-	baseURL: `${baseURL}/api/auth`,
 	plugins: [convexClient(), lastLoginMethodClient()],
 });


### PR DESCRIPTION
## Problem
Login page still stuck on Loading

## Root Cause
I added a manual `baseURL` to the auth client, but the `convexClient()` plugin automatically handles routing to the Convex .site URL. My manual baseURL was interfering with this.

## Fix
Removed the baseURL - let the convexClient plugin handle it automatically

## Testing
✅ Build passes
✅ Convex endpoints tested and working