### PR TITLE
fix: prevent redirect loop on sign-in page

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -16,8 +16,8 @@ export async function middleware(request: NextRequest) {
 		return NextResponse.redirect(new URL("/auth/sign-in", request.url));
 	}
 
-	// Only validate session when needed: sign-in page or protected routes with cookies
-	if (pathname === "/auth/sign-in" || (!isPublicRoute && hasCookies)) {
+	// Only validate session when we have cookies
+	if (hasCookies) {
 		const sessionValid = await checkSession(request);
 
 		// If on sign-in page with valid session, redirect to dashboard


### PR DESCRIPTION
Fixes ERR_TOO_MANY_REDIRECTS

Root cause: Middleware checked session on EVERY /auth/sign-in load, even with no cookies.

Fix: Only check session when cookies exist.