### PR TITLE
fix: wrap useSearchParams in Suspense boundary for Next.js 15

### DIFF
--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { GalleryVerticalEnd, Github } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 
-export default function LoginPage() {
+function LoginPageContent() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const [error, setError] = useState("");
@@ -183,5 +183,17 @@ export default function LoginPage() {
 				/>
 			</div>
 		</div>
+	);
+}
+
+export default function LoginPage() {
+	return (
+		<Suspense fallback={
+			<div className="flex min-h-svh items-center justify-center">
+				<div className="text-muted-foreground">Loading...</div>
+			</div>
+		}>
+			<LoginPageContent />
+		</Suspense>
 	);
 }


### PR DESCRIPTION
## Fixes Build Error

Resolves Vercel build failure:
```
⨯ useSearchParams() should be wrapped in a suspense boundary at page "/auth/sign-in"
```

## Problem
Next.js 15 requires components using `useSearchParams()` to be wrapped in a Suspense boundary to handle client-side rendering bailout properly.

## Solution
- Extracted login page content into `LoginPageContent` component
- Wrapped it in a Suspense boundary with loading fallback
- Maintains all existing functionality while fixing the build

## Testing
- ✅ Build should now succeed
- ✅ Sign-in page still works correctly
- ✅ OAuth flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)