### PR TITLE
fix: use Convex Better Auth instead of SQLite

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,7 +63,6 @@
     "@tailwindcss/postcss": "^4.1.10",
     "@tanstack/react-query-devtools": "^5.85.5",
     "@testing-library/react": "^16.1.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/react": "~19.1.10",
     "@types/react-dom": "^19",

--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -1,63 +1,6 @@
-import { betterAuth } from "better-auth";
-import { nextCookies } from "better-auth/next-js";
-import Database from "better-sqlite3";
+import { nextJsHandler } from "@convex-dev/better-auth/nextjs";
 
-// Create and configure database (singleton)
-const db = new Database(process.cwd() + "/.auth.db");
-db.pragma("foreign_keys = ON");
-
-// Get base URL from environment
-const baseURL = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
-
-// Build social providers from environment variables
-const socialProviders: Record<string, any> = {};
-
-if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
-	socialProviders.github = {
-		clientId: process.env.GITHUB_CLIENT_ID,
-		clientSecret: process.env.GITHUB_CLIENT_SECRET,
-	};
-}
-
-if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
-	socialProviders.google = {
-		clientId: process.env.GOOGLE_CLIENT_ID,
-		clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-	};
-}
-
-// Create auth instance as singleton
-const auth = betterAuth({
-	database: db,
-	databaseType: "sqlite",
-	secret: process.env.BETTER_AUTH_SECRET || "dev-secret",
-	baseURL,
-	socialProviders,
-	plugins: [nextCookies()],
-	trustedOrigins: [baseURL],
-	session: {
-		expiresIn: 60 * 60 * 24 * 7, // 7 days
-		updateAge: 60 * 60 * 24, // 1 day
-		cookieCache: {
-			enabled: true,
-			maxAge: 5 * 60, // 5 minutes
-		},
-	},
-	advanced: {
-		generateSchema: true,
-		useSecureCookies: process.env.NODE_ENV === "production",
-		crossSubDomainCookies: {
-			enabled: false,
-		},
-		cookiePrefix: "openchat",
-	},
-});
-
-// Export as Next.js App Router handlers
-export async function GET(request: Request) {
-	return await auth.handler(request);
-}
-
-export async function POST(request: Request) {
-	return await auth.handler(request);
-}
+// Export the Convex Better Auth handler for Next.js
+// This uses Convex as the database backend instead of SQLite
+// Sessions and user data are stored in Convex
+export const { GET, POST } = nextJsHandler();

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,8 +1,8 @@
 import { createAuthClient } from "better-auth/react";
 import { convexClient } from "@convex-dev/better-auth/client/plugins";
 
-// Create auth client with baseURL for standalone Better Auth
+// Create auth client with Convex Better Auth
+// The convexClient plugin handles routing to /api/auth/[...all]
 export const authClient = createAuthClient({
-	baseURL: process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
 	plugins: [convexClient()],
 });

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,6 @@
         "@tailwindcss/postcss": "^4.1.10",
         "@tanstack/react-query-devtools": "^5.85.5",
         "@testing-library/react": "^16.1.0",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/react": "~19.1.10",
         "@types/react-dom": "^19",


### PR DESCRIPTION
## Summary
- Replaces standalone Better Auth (SQLite) with Convex Better Auth
- Fixes production authentication errors caused by SQLite on Vercel serverless

## Problem
SQLite doesn't work on Vercel's serverless environment. The standalone Better Auth was trying to open a database file which fails on serverless:
```
SqliteError: unable to open database file
GET /api/auth/get-session 500 (Internal Server Error)
POST /api/auth/sign-in/social 405 (Method Not Allowed)
```

## Solution
Switched to Convex Better Auth which stores sessions and user data in Convex (already set up):

### Changes Made

1. **Updated API route** (`apps/web/src/app/api/auth/[...all]/route.ts`):
   - Replaced standalone Better Auth with `nextJsHandler` from `@convex-dev/better-auth/nextjs`
   - This proxies auth requests to Convex deployment

2. **Updated auth client** (`apps/web/src/lib/auth-client.ts`):
   - Removed `baseURL` config (convexClient plugin handles routing automatically)
   - Simplified to just use convexClient plugin

3. **Removed SQLite dependencies**:
   - Removed `@types/better-sqlite3` package
   - No longer need SQLite for auth storage

## Infrastructure
The Convex Better Auth setup was already configured:
- ✅ `apps/server/convex/auth.ts` - Better Auth instance with Convex adapter
- ✅ `apps/server/convex/http.ts` - HTTP routes registered via `authComponent.registerRoutes`
- ✅ `apps/web/src/components/providers.tsx` - ConvexBetterAuthProvider wrapping app

## Test Plan
- [x] Build succeeds locally
- [ ] Deploy to production
- [ ] Verify authentication works on osschat.dev
- [ ] Test Google OAuth sign-in
- [ ] Test GitHub OAuth sign-in

## Related
- Reverts the SQLite approach from PR #231
- Builds on existing Convex Better Auth setup already in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)