### PR TITLE
fix: check for both Better Auth cookie names in middleware

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -12,10 +12,10 @@ export async function middleware(request: NextRequest) {
 		return NextResponse.next();
 	}
 
-	// For protected routes, check if session cookie exists
-	// Note: We only check for cookie EXISTENCE, not validity
-	// Actual session validation happens in Server Components
-	const sessionToken = request.cookies.get("openchat.session_token");
+	// For protected routes, check if Better Auth session exists
+	// Better Auth uses multiple cookies for session management
+	const sessionToken = request.cookies.get("better-auth.session_token") ||
+	                     request.cookies.get("openchat.session_token");
 
 	// If no session cookie, redirect to sign-in
 	if (!sessionToken) {


### PR DESCRIPTION
## Summary
- Fixes middleware to check for both `better-auth.session_token` and `openchat.session_token` cookies
- Resolves issue where users get redirected back to sign-in after successful OAuth

## Problem
After successful OAuth authentication, the session is created in Convex, but the middleware redirects users back to `/auth/sign-in` because it can't find the expected cookie.

## Root Cause
The middleware was only checking for `openchat.session_token`, but Convex Better Auth may set cookies with the default `better-auth.` prefix instead.

## Solution
Updated middleware to check for both cookie names:
```typescript
const sessionToken = request.cookies.get("better-auth.session_token") ||
                     request.cookies.get("openchat.session_token");
```

## Test Plan
- [ ] Deploy to production
- [ ] Test Google OAuth sign-in flow
- [ ] Test GitHub OAuth sign-in flow
- [ ] Verify user stays logged in after successful auth
- [ ] Verify /dashboard is accessible after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)