### PR TITLE
fix: add maxTokens limit to prevent excessive token requests

### DIFF
--- a/apps/web/src/app/api/chat/chat-handler.ts
+++ b/apps/web/src/app/api/chat/chat-handler.ts
@@ -42,6 +42,13 @@ const STREAM_SMOOTH_DELAY_MS = (() => {
 	if (!Number.isFinite(parsed)) return 12;
 	return parsed < 0 ? 0 : parsed;
 })();
+const MAX_TOKENS = (() => {
+	const raw = process.env.OPENROUTER_MAX_TOKENS;
+	if (!raw || raw.trim() === "") return 8192;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0) return 8192;
+	return Math.min(parsed, 32768); // Cap at 32k to prevent excessive token usage
+})();
 
 type StreamPersistRequest = {
 	userId: string;
@@ -466,6 +473,7 @@ export function createChatHandler(options: ChatHandlerOptions = {}) {
 			const result = await streamTextImpl({
 				model,
 				messages: convertToCoreMessagesImpl(safeMessages),
+				maxTokens: MAX_TOKENS,
 				experimental_transform: smoothStream({
 					delayInMs: STREAM_SMOOTH_DELAY_MS,
 					chunking: "word",


### PR DESCRIPTION
## Summary

Fixes the issue where sending a simple message like "hi" would request up to **230,399 tokens** from OpenRouter, causing 402 payment errors when the API key doesn't have enough credits remaining.

## Problem

When a user sends ANY message (even just "hi"), the chat API was requesting the model's **maximum output tokens** from OpenRouter because no `maxTokens` parameter was set. This caused:

```
Error: This request requires more credits, or fewer max_tokens. 
You requested up to 230399 tokens, but can only afford 146666.
```

The AI SDK was defaulting to the model's full capacity (200k+ tokens for large models), which is:
- **Wasteful** - most responses don't need 200k+ tokens
- **Expensive** - uses up API credits unnecessarily
- **Breaks** - when credit limit is lower than requested tokens

## Solution

Added a `maxTokens` limit to the `streamText()` API call:

- **Default: 8,192 tokens** (reasonable for most chat responses)
- **Configurable** via `OPENROUTER_MAX_TOKENS` environment variable
- **Capped at 32k tokens** to prevent excessive usage even if misconfigured
- Applied to line 476 in `chat-handler.ts`

## Changes

**File:** `apps/web/src/app/api/chat/chat-handler.ts`

1. Added `MAX_TOKENS` constant (lines 45-51)
2. Added `maxTokens: MAX_TOKENS` parameter to `streamText()` call (line 476)

## Test Plan

- [ ] Send a simple message like "hi" - should work without 402 errors
- [ ] Verify OpenRouter request asks for 8,192 tokens (or configured amount) instead of 200k+
- [ ] Verify longer conversations still work properly
- [ ] Verify response quality is unaffected

## Impact

- **Users can now chat** without hitting credit limits on simple messages
- **Token usage is predictable** and controlled
- **API costs are reduced** by not requesting unnecessary tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)