### PR TITLE
Format pricing per 1M tokens in model selector

### DIFF
--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -36,6 +36,8 @@ type ModelSelectorProps = {
 	loading?: boolean
 }
 
+const TOKENS_PER_MILLION = 1_000_000
+
 function formatCost(cost: number | null) {
 	if (cost == null || !Number.isFinite(cost)) return "–"
 	const abs = Math.abs(cost)
@@ -53,8 +55,15 @@ function formatCost(cost: number | null) {
 	}).format(cost)
 }
 
+const scaleCostToMillion = (cost: number | null) => {
+	if (cost == null || !Number.isFinite(cost)) return null
+	return cost * TOKENS_PER_MILLION
+}
+
 function formatPricing(pricing: NonNullable<ModelSelectorOption["pricing"]>) {
-	return `In: ${formatCost(pricing.prompt)} · Out: ${formatCost(pricing.completion)} per 1M tokens`
+	const promptPerMillion = scaleCostToMillion(pricing.prompt)
+	const completionPerMillion = scaleCostToMillion(pricing.completion)
+	return `In: ${formatCost(promptPerMillion)} · Out: ${formatCost(completionPerMillion)} per 1M tokens`
 }
 
 const getInitial = (label: string) => {


### PR DESCRIPTION
## Summary
- Displays both prompt (input) and completion (output) costs per 1M tokens in the ModelSelector pricing display
- Introduces a helper to convert per-token costs to per-1M-token costs for clearer pricing information

## Changes
### Pricing helpers
- Added constant TOKENS_PER_MILLION = 1_000_000
- Added scaleCostToMillion(cost: number | null) to convert a cost to cost per 1M tokens (returns null for invalid input)

### Pricing display
- Updated formatPricing to compute promptPerMillion and completionPerMillion using scaleCostToMillion
- Renders: `In: <cost per 1M tokens> · Out: <cost per 1M tokens> per 1M tokens`
- Ensures both sides show per-1M-tokens pricing consistently

## Testing/Validation
- [x] Verify UI shows prompt and completion prices per 1M tokens in ModelSelector
- [x] Confirm null/invalid costs display as “–”
- [x] Ensure formatting remains consistent with existing UI styles

## Notes
- This is a purely presentation-layer update; no backend changes.
- No API contract changes expected.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6ddb955a-6555-4017-a88f-087a382f9d87

📝 Addresses #248