### PR TITLE
Review and resolve GitHub issue 246

### DIFF
--- a/apps/web/src/components/account-settings-modal.tsx
+++ b/apps/web/src/components/account-settings-modal.tsx
@@ -214,7 +214,7 @@ export function AccountSettingsModal({ open, onClose }: { open: boolean; onClose
 
 	const modal = (
 		<div className="fixed inset-0 z-50">
-			<div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden />
+			<div className="absolute inset-0 bg-black/20 dark:bg-black/50" onClick={onClose} aria-hidden />
 			<div className="pointer-events-auto absolute inset-0 flex items-center justify-center p-4">
 				<div
 					ref={dialogRef}

--- a/apps/web/src/components/logo.tsx
+++ b/apps/web/src/components/logo.tsx
@@ -23,8 +23,7 @@ const LogoMark = ({ className, uniColor }: { className?: string; uniColor?: bool
 			/>
 			<path
 				d="M7.5 6.5H14.5V8.25H7.5V6.5ZM6 10.5H16V12.25H6V10.5ZM8.5 14.5H13.5V16.25H8.5V14.5Z"
-				fill="white"
-				fillOpacity="0.9"
+				className="fill-foreground/90 dark:fill-white/90"
 			/>
 			<defs>
 				<linearGradient

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
 				default:
 					"bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
 				destructive:
-					"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+					"bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline:
 					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
 				secondary:

--- a/apps/web/src/components/ui/progressive-blur.tsx
+++ b/apps/web/src/components/ui/progressive-blur.tsx
@@ -31,6 +31,8 @@ export function ProgressiveBlur({
     <div className={cn('relative', className)}>
       {Array.from({ length: layers }).map((_, index) => {
         const angle = GRADIENT_ANGLES[direction];
+        // Note: White is used for mask gradient (white = visible, black = hidden in CSS masks)
+        // This is theme-independent as it only controls the mask, not visible colors
         const gradientStops = [
           index * segmentSize,
           (index + 1) * segmentSize,


### PR DESCRIPTION
- Change destructive button to use semantic text-destructive-foreground color instead of hardcoded white for better theme compatibility
- Update logo SVG icon bars to be theme-aware (dark in light mode, white in dark mode) for improved visibility
- Fix modal backdrop opacity to be lighter in light mode (20%) and darker in dark mode (50%) for better contrast
- Add clarifying comment to progressive blur explaining mask gradient is theme-independent

These changes address issue #246 to make light mode better by removing hardcoded color values and using semantic theme tokens throughout the UI components.