### PR TITLE
chore: force Vercel cache rebuild

### DIFF
--- a/apps/web/.vercel-cache-bust
+++ b/apps/web/.vercel-cache-bust
@@ -1,0 +1,6 @@
+# Vercel Cache Bust
+
+This file forces Vercel to rebuild with a fresh cache.
+
+Build timestamp: 2025-11-08T02:10:00Z
+Reason: Fix build cache corruption issue


### PR DESCRIPTION
## Problem

Vercel builds were failing due to Next.js cache corruption:
```
Type error: Cannot find name 'logWarn'
```

Even though the import exists in `logger-server.ts`, stale `.next` cache was causing TypeScript to fail.

## Solution

This PR forces Vercel to rebuild with a fresh cache by adding a cache-bust file.

## Local Verification

✅ `rm -rf .next && bun run build` works perfectly in **42 seconds**

## Expected Result

This should trigger a fresh Vercel build that completes in ~2-3 minutes.

---

Will merge immediately to trigger rebuild.