### PR TITLE
fix(middleware): replace Node.js crypto with Web Crypto API for edge runtime

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,15 +1,21 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { randomBytes } from "crypto";
 
 /**
  * Generate a unique request correlation ID
  *
  * Format: {timestamp}-{random}
  * Example: 1699564231-a3f9c8d2
+ *
+ * Uses Web Crypto API (edge-compatible) instead of Node.js crypto module
  */
 function generateCorrelationId(): string {
 	const timestamp = Date.now().toString(36);
-	const random = randomBytes(4).toString("hex");
+	// Use Web Crypto API which is available in Edge Runtime
+	const randomArray = new Uint8Array(4);
+	crypto.getRandomValues(randomArray);
+	const random = Array.from(randomArray)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
 	return `${timestamp}-${random}`;
 }
 


### PR DESCRIPTION
## Summary
Fixed production build failure caused by using Node.js `crypto` module in middleware, which doesn't work in Edge Runtime.

## Changes
- Replaced `randomBytes()` from Node.js crypto with `crypto.getRandomValues()` from Web Crypto API
- Web Crypto API is edge-compatible and works in Vercel Edge Runtime
- Maintains same correlation ID format: `{timestamp}-{random}`

## Root Cause
The middleware was importing Node.js's `crypto` module:
```typescript
import { randomBytes } from "crypto";
```

This caused the error:
```
A Node.js module is loaded ('crypto' at line 2) which is not supported in the Edge Runtime.
```

## Solution
Use Web Crypto API which is available in all edge runtimes:
```typescript
const randomArray = new Uint8Array(4);
crypto.getRandomValues(randomArray);
const random = Array.from(randomArray)
    .map((b) => b.toString(16).padStart(2, "0"))
    .join("");
```

## Test Plan
- [x] Local build passes (`bun run build`)
- [x] No edge runtime errors in middleware
- [x] Correlation ID generation still works

Fixes edge runtime error in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)