### PR TITLE
fix(auth): pass convexSiteUrl to nextJsHandler

### DIFF
--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -6,7 +6,8 @@ import { logWarn } from "@/lib/logger-server";
 // Export the Convex Better Auth handler for Next.js
 // This uses Convex as the database backend instead of SQLite
 // Sessions and user data are stored in Convex
-const { GET: originalGET, POST: originalPOST } = nextJsHandler();
+const convexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_SITE_URL || "https://outgoing-setter-201.convex.site";
+const { GET: originalGET, POST: originalPOST } = nextJsHandler({ convexSiteUrl });
 
 // Rate limiter for auth endpoints to prevent brute force attacks
 // More restrictive than general API endpoints


### PR DESCRIPTION
## Summary
Fixes auth endpoints still returning HTTP 500 even after adding the @convex-dev/better-auth package.

## Problem  
After PR #260 added the missing package, auth endpoints were still failing because `nextJsHandler()` wasn't configured to connect to the Convex backend.

## Root Cause
```typescript
// BEFORE - Missing convexSiteUrl:
const { GET, POST } = nextJsHandler(); // ❌ Can't connect to Convex!

// AFTER - With convexSiteUrl:
const convexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_SITE_URL || "https://outgoing-setter-201.convex.site";
const { GET, POST } = nextJsHandler({ convexSiteUrl }); // ✅ Connects to Convex
```

The handler signature:
```typescript
export declare const nextJsHandler: (opts?: {
    convexSiteUrl?: string;
}) => { GET, POST }
```

Without `convexSiteUrl`, the handler couldn't route auth requests to the Convex backend.

## Changes
- Added `convexSiteUrl` parameter to `nextJsHandler()` call
- Reads from `NEXT_PUBLIC_CONVEX_SITE_URL` environment variable  
- Falls back to hardcoded URL as safety net

## Impact
- ✅ Auth endpoints will return 200 instead of 500
- ✅ GitHub OAuth login flow will work
- ✅ Users can successfully sign in

## Test Plan
- [x] Local build passes
- [ ] Verify production deployment succeeds
- [ ] Test GitHub OAuth login flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)