### PR TITLE
debug: add error logging to auth route

### DIFF
--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -67,9 +67,33 @@ async function withAuthRateLimit(
 
 // Export wrapped handlers with rate limiting
 export async function GET(request: Request) {
-	return withAuthRateLimit(request, originalGET);
+	try {
+		return await withAuthRateLimit(request, originalGET);
+	} catch (error) {
+		console.error("[Auth Route Error]", error);
+		return NextResponse.json(
+			{
+				error: "Internal server error",
+				message: error instanceof Error ? error.message : "Unknown error",
+				stack: error instanceof Error ? error.stack : undefined,
+			},
+			{ status: 500 },
+		);
+	}
 }
 
 export async function POST(request: Request) {
-	return withAuthRateLimit(request, originalPOST);
+	try {
+		return await withAuthRateLimit(request, originalPOST);
+	} catch (error) {
+		console.error("[Auth Route Error]", error);
+		return NextResponse.json(
+			{
+				error: "Internal server error",
+				message: error instanceof Error ? error.message : "Unknown error",
+				stack: error instanceof Error ? error.stack : undefined,
+			},
+			{ status: 500 },
+		);
+	}
 }


### PR DESCRIPTION
## Summary
Add try-catch blocks and detailed error logging to diagnose HTTP 500 errors on auth endpoints.

## Issue
Auth endpoints returning HTTP 500 but no error details visible. This PR adds:
- Try-catch blocks around GET/POST handlers
- Detailed error logging with stack traces
- JSON error responses to help debug the issue

## Expected Output
After deploying this, we'll be able to see the actual error message and stack trace when calling the auth endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)