### PR TITLE
fix(auth): create new Response instead of mutating headers

### DIFF
--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -58,11 +58,18 @@ async function withAuthRateLimit(
 		windowMs: authRateLimiter.getStats().config.windowMs,
 	});
 
+	// Create a new response with rate limit headers
+	// (Response headers are immutable in Next.js App Router)
+	const newHeaders = new Headers(response.headers);
 	Object.entries(rateLimitHeaders).forEach(([key, value]) => {
-		response.headers.set(key, value);
+		newHeaders.set(key, value);
 	});
 
-	return response;
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: newHeaders,
+	});
 }
 
 // Export wrapped handlers with rate limiting


### PR DESCRIPTION
## Summary  
Fix HTTP 500 errors by creating a new Response instead of mutating immutable headers.

## Issue
Auth endpoints were returning HTTP 500 because we were trying to modify Response headers which are immutable in Next.js App Router.

## Solution
- Create new Response object with copied headers
- Add rate limit headers to the new Headers object  
- Return the new Response with all headers combined

## Testing
After this fix:
- ✅ `/api/auth/get-session` should return HTTP 200 with `null` body
- ✅ `/api/auth/sign-in/github` should return HTTP 302 redirect to GitHub OAuth  
- ✅ Rate limit headers should be present in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)