### PR TITLE
fix: replace skeleton loader with 'No messages yet' in new chats

### DIFF
--- a/apps/web/src/components/chat-room.tsx
+++ b/apps/web/src/components/chat-room.tsx
@@ -750,7 +750,6 @@ function ChatRoom({ chatId, initialMessages }: ChatRoomProps) {
         optimisticMessages={messages}
         paddingBottom={conversationPaddingBottom}
         className="flex-1 rounded-xl bg-background/40 shadow-inner overflow-hidden"
-        loading={!messages.length}
       />
 
       <div className="pointer-events-none fixed bottom-4 left-6 right-6 z-30 flex justify-center transition-all duration-300 ease-in-out md:left-[calc(var(--sb-width)+1.5rem)] md:right-6">


### PR DESCRIPTION
## Summary

Fixed the issue where a skeleton loader was constantly showing in new chats. Now displays "No messages yet. Say hi!" instead.

## Changes

- Removed the `loading={!messages.length}` prop from `ChatMessagesFeed` in `chat-room.tsx`
- The component now uses the default `loading=false` value
- Empty chat state now shows the appropriate "No messages yet" message

Fixes #271

🤖 Generated with [Claude Code](https://claude.ai/code)