### PR TITLE
fix: add missing template literal backticks for opacity interpolation

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -43,7 +43,7 @@ export default async function DashboardLayout({ children }: { children: ReactNod
 			</div>
             <main id="main-content" className="relative flex min-h-0 flex-1 flex-col overflow-hidden md:ml-[var(--sb-width)] transition-[margin] duration-300 ease-in-out w-full" tabIndex={-1}>
                 <div className="pointer-events-auto absolute left-4 top-4 z-20 hidden md:block">
-                    <div className="flex items-center rounded-xl border bg-card/${opacity.subtle} px-2 py-1.5 shadow-md backdrop-blur">
+                    <div className={`flex items-center rounded-xl border bg-card/${opacity.subtle} px-2 py-1.5 shadow-md backdrop-blur`}>
                         <SidebarCollapseButton />
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Fixed critical syntax error in dashboard layout where template literal backticks were missing
- Line 46 was using `bg-card/${opacity.subtle}` without backticks, causing literal text render
- Now correctly uses template literals: `` `bg-card/${opacity.subtle}` ``

## Context
This addresses the **1/5 confidence score** feedback from Greptile AI review on PR #274, which flagged:
> "Line 46 has a syntax error: missing template literal backticks for the className that uses ${opacity.subtle} interpolation. This will cause the background opacity modifier to render as literal text instead of being evaluated, resulting in invalid CSS."

## Test plan
- [x] Verify className now correctly evaluates opacity variable
- [x] Check that backdrop styling renders properly
- [x] Ensure no TypeScript/build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)