### PR TITLE
fix: add CONVEX_DEPLOY_KEY to turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,10 @@
 				"CORS_ORIGIN",
 				"TRUST_PROXY_FORWARDED",
 				"POSTHOG_API_KEY",
-				"POSTHOG_HOST"
+				"POSTHOG_HOST",
+				"CONVEX_DEPLOY_KEY",
+				"NEXT_PUBLIC_DEPLOYMENT",
+				"VERCEL_URL"
 			]
 		},
 		"lint": {


### PR DESCRIPTION
## Problem
Turbo was filtering out `CONVEX_DEPLOY_KEY` and other required environment variables, causing Convex deployments to fail in Vercel.

## Solution
Added to `turbo.json` env list:
- `CONVEX_DEPLOY_KEY` - Required for Convex deployments
- `NEXT_PUBLIC_DEPLOYMENT` - Needed for preview seed detection  
- `VERCEL_URL` - Used in preview deployment URLs

## Impact
Fixes preview deployment builds that were failing with:
```
✖ Vercel build environment detected but no Convex deployment configuration found.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)