### PR TITLE
fix: add --cmd-url-env-var-name for Next.js NEXT_PUBLIC_CONVEX_URL

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "convex dev",
-    "build": "if [ \"$NEXT_PUBLIC_DEPLOYMENT\" = \"preview\" ]; then convex deploy --cmd 'cd ../web && bun run build' --preview-run previewSeed --preview-create NEXT_PUBLIC_DEPLOYMENT=preview NEXT_PUBLIC_APP_URL=https://$VERCEL_URL; else convex deploy --cmd 'cd ../web && bun run build'; fi",
+    "build": "if [ \"$NEXT_PUBLIC_DEPLOYMENT\" = \"preview\" ]; then convex deploy --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL --cmd 'cd ../web && bun run build' --preview-run previewSeed --preview-create NEXT_PUBLIC_DEPLOYMENT=preview NEXT_PUBLIC_APP_URL=https://$VERCEL_URL; else convex deploy --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL --cmd 'cd ../web && bun run build'; fi",
     "check-types": "tsc --noEmit || true",
     "test": "echo \"No Convex tests yet\""
   },


### PR DESCRIPTION
## Summary
- Add `--cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL` to Convex deploy commands

## Problem
Preview deployments were failing with:
```
Error: NEXT_PUBLIC_CONVEX_URL is not configured
```

The issue was that `convex deploy` sets `CONVEX_URL` by default, but Next.js requires environment variables exposed to the browser to be prefixed with `NEXT_PUBLIC_`.

## Solution
Use the `--cmd-url-env-var-name` flag to tell Convex to set `NEXT_PUBLIC_CONVEX_URL` instead of the default `CONVEX_URL`.

This flag is added to both preview and production build commands to ensure consistent behavior.

## References
- [Convex CLI Documentation](https://docs.convex.dev/cli)
- [Next.js Environment Variables](https://nextjs.org/docs/pages/guides/environment-variables)

## Test plan
- [ ] Verify preview deployment builds successfully
- [ ] Verify `NEXT_PUBLIC_CONVEX_URL` is set correctly
- [ ] Verify app loads without errors
- [ ] Verify test user seeding works

🤖 Generated with [Claude Code](https://claude.com/claude-code)