### PR TITLE
fix: restore vercel.json to fix CSS/static asset serving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+	"buildCommand": "bun run build",
+	"outputDirectory": "apps/web/.next",
+	"installCommand": "bun install"
+}


### PR DESCRIPTION
## Summary
- Restores vercel.json configuration that was removed in d0f4583
- Fixes CSS and static assets not loading on osschat.dev production

## Root Cause
When vercel.json was removed, Vercel lost the configuration pointing to `apps/web/.next` as the output directory. Even though the web app is still being built correctly (via server's convex deploy), Vercel doesn't know where to find the built files to serve them.

## Changes
- Added vercel.json with:
  - `buildCommand`: "bun run build" (triggers server → convex → web build)
  - `outputDirectory`: "apps/web/.next" (tells Vercel where the Next.js app is)
  - `installCommand`: "bun install"
  - Auto-detection of Next.js framework (no framework: null)

## Test plan
- [ ] Verify Vercel deployment succeeds
- [ ] Check osschat.dev loads with CSS properly
- [ ] Verify all static assets (images, fonts, etc.) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)