### PR TITLE
fix: correct outputDirectory to .next instead of apps/web/.next

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
 	"buildCommand": "bun run build",
-	"outputDirectory": "apps/web/.next",
+	"outputDirectory": ".next",
 	"installCommand": "bun install"
 }


### PR DESCRIPTION
## Summary
- Fixes outputDirectory path duplication in vercel.json
- Changes from `apps/web/.next` to `.next`

## Root Cause
Vercel auto-detected the app in the `apps/web` directory, then applied the `outputDirectory: "apps/web/.next"` on top of that, resulting in the path `/vercel/path0/apps/web/apps/web/.next` which doesn't exist.

## Fix
Since Vercel already knows the app is in `apps/web/`, the `outputDirectory` should be relative to that detected directory, not the monorepo root. Changed to `.next` which correctly points to `apps/web/.next` from Vercel's perspective.

## Error Fixed
```
The file "/vercel/path0/apps/web/apps/web/.next/routes-manifest.json" couldn't be found.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)