### PR TITLE
fix: add missing tw-animate-css dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
     "sonner": "^2.0.5",
     "streamdown": "^1.2.0",
     "tailwind-merge": "^3.3.1",
+    "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.1",
     "zod": "^4.0.2"
   },


### PR DESCRIPTION
## Summary
- Adds missing `tw-animate-css` dependency to apps/web/package.json
- Fixes CSS files being generated as empty (0 bytes)

## Root Cause
The `src/index.css` file imports `tw-animate-css` on line 7, but the package was not installed. This caused the PostCSS/Tailwind build to fail silently, resulting in empty CSS files being deployed to production.

## Fix
Installed `tw-animate-css@1.4.0` as a dependency. After this change:
- CSS files are generated with proper content (82KB + 25KB)
- All Tailwind styles and animations work correctly

## Verification
Tested locally:
```bash
bunx next build
find .next/static -name "*.css" -exec wc -c {} \;
# Output: 82817 and 25605 bytes (previously 0)
```

Fixes the CSS loading issue on osschat.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)