### PR TITLE
fix: set Vercel Analytics to production mode

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -100,7 +100,7 @@ posthog.init('phc_hWOxd18YQVTr0cSQ8X5OC3mfZY29cAthAXkxAPxiuqy', {
 					{children}
 				</Providers>
 				<SpeedInsights />
-			<Analytics />
+			<Analytics mode="production" />
 			</body>
 		</html>
 	);


### PR DESCRIPTION
## Summary
- Set `mode="production"` on the Analytics component to ensure it works correctly in production environments
- Fixes issue where Analytics wasn't tracking due to automatic environment detection failing

According to Vercel documentation, explicitly setting the mode is useful when automatic environment detection fails or when a specific mode needs to be enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)