### PR TITLE
fix: correct Graphite logo aspect ratio in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ OpenChat is an open-source AI chat workspace that you can self-host or run on Op
       <picture>
         <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/opentech1/openchat/main/apps/web/public/sponsors/graphite-black.png">
         <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentech1/openchat/main/apps/web/public/sponsors/graphite-white.png">
-        <img width="180" height="90" alt="Graphite" src="https://raw.githubusercontent.com/opentech1/openchat/main/apps/web/public/sponsors/graphite-black.png">
+        <img width="120" height="120" alt="Graphite" src="https://raw.githubusercontent.com/opentech1/openchat/main/apps/web/public/sponsors/graphite-black.png">
       </picture>
     </td>
   </tr>


### PR DESCRIPTION
## Summary
Fix stretched Graphite logo in README by correcting dimensions to match actual logo aspect ratio.

## Problem
- Graphite logos are 800x800 (square)
- README was displaying them as 180x90 (2:1 ratio)
- This caused visible distortion/stretching

## Solution
- Changed dimensions to 120x120 to maintain square aspect ratio
- Logo now displays correctly without stretching

## Test Plan
- [x] Verified logo dimensions are 800x800
- [ ] Check README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)