### PR TITLE
feat: configure Conductor scripts for local Convex development

### DIFF
--- a/conductor-run.sh
+++ b/conductor-run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+echo "Starting OpenChat for Conductor..."
+echo ""
+
+# Run Convex codegen once for backend
+echo "Running Convex codegen..."
+cd apps/server && bunx convex dev --local --once
+cd ../..
+
+echo ""
+echo "Starting dev servers..."
+# Run dev without Turborepo UI (plain output)
+turbo -F web -F server dev --no-ui

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -56,13 +56,8 @@ fi
 # Set up Convex
 echo ""
 echo "Setting up Convex..."
-echo "⚠️  You'll need to run 'bun run convex:dev' to initialize Convex"
-echo "   This will:"
-echo "   - Connect to your Convex project (or create a new one)"
-echo "   - Generate TypeScript types"
-echo "   - Set CONVEX_URL and NEXT_PUBLIC_CONVEX_URL in your .env.local"
-echo ""
-echo "   After running 'convex:dev' once, your workspace will be ready!"
+cd apps/server && bunx convex dev --local --once
+cd ../..
 
 echo ""
 echo "======================================"
@@ -71,6 +66,5 @@ echo "======================================"
 echo ""
 echo "Next steps:"
 echo "  1. Review your .env.local file and add any missing secrets"
-echo "  2. Run 'bun run convex:dev' to initialize Convex (first time only)"
-echo "  3. Click the 'Run' button to start the dev servers"
+echo "  2. Click the 'Run' button to start the dev servers"
 echo ""

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "./conductor-setup.sh",
-    "run": "bun run dev",
+    "run": "./conductor-run.sh",
     "archive": ""
   },
   "runScriptMode": "nonconcurrent"


### PR DESCRIPTION
## Summary
- Updates Conductor setup script to run `bunx convex dev --local --once` for initial codegen
- Creates new `conductor-run.sh` script that generates Convex types once then starts dev servers
- Configures Turborepo to run in plain mode (`--no-ui`) for cleaner output in Conductor
- Regular dev workflow outside Conductor remains unchanged

## Test plan
- [ ] Test Conductor setup script runs successfully
- [ ] Verify Convex codegen completes during setup
- [ ] Confirm dev servers start properly with plain output
- [ ] Ensure regular `bun run dev` workflow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)