### PR TITLE
fix: improve Conductor run script to handle unconfigured Convex

### DIFF
--- a/conductor-run.sh
+++ b/conductor-run.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-set -e
 
 echo "Starting OpenChat for Conductor..."
 echo ""
 
-# Try to run Convex codegen once for backend (skip if not configured yet)
-echo "Running Convex codegen..."
-(cd apps/server && bunx convex dev --local --once) || echo "⚠️  Skipping Convex codegen (not configured yet)"
+# Check if Convex is configured by looking for deployment URL
+if [ -f ".env.local" ] && grep -q "CONVEX_URL" .env.local 2>/dev/null; then
+  echo "Running Convex codegen..."
+  cd apps/server && bunx convex dev --local --once && cd ../..
+  echo ""
+fi
 
-echo ""
 echo "Starting dev servers..."
-# Run dev without Turborepo UI (plain output)
-turbo -F web -F server dev --no-ui
+# Use bun run dev which calls turbo with proper setup
+FORCE_COLOR=1 bun run dev


### PR DESCRIPTION
## Summary
Fixes issues preventing Conductor from running the dev servers properly.

**Problems solved:**
1. ✅ Convex CLI no longer prompts for input in non-interactive mode
2. ✅ Fixed "turbo: command not found" error
3. ✅ Dev servers start successfully even without Convex configured

**Changes:**
- Only run Convex codegen if `.env.local` exists with `CONVEX_URL` configured
- Use `bun run dev` instead of calling `turbo` directly (fixes PATH issues)
- Remove `set -e` to allow graceful fallbacks
- Add `FORCE_COLOR=1` to preserve colored terminal output

## Test plan
- [x] Run script with unconfigured Convex - skips codegen gracefully
- [x] Dev servers start successfully
- [x] No interactive prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)