### PR TITLE
fix: remove Convex codegen from Conductor run script

### DIFF
--- a/conductor-run.sh
+++ b/conductor-run.sh
@@ -2,13 +2,10 @@
 
 echo "Starting OpenChat for Conductor..."
 echo ""
-
-# Check if Convex is configured by looking for deployment URL
-if [ -f ".env.local" ] && grep -q "CONVEX_URL" .env.local 2>/dev/null; then
-  echo "Running Convex codegen..."
-  cd apps/server && bunx convex dev --local --once && cd ../..
-  echo ""
-fi
+echo "⚠️  Note: Skipping Convex codegen for Conductor"
+echo "   The app will run without backend database functionality"
+echo "   To use Convex, run 'bun run convex:dev' separately"
+echo ""
 
 echo "Starting dev servers..."
 # Use bun run dev which calls turbo with proper setup


### PR DESCRIPTION
## Summary
Completely removes Convex codegen from the Conductor run script to eliminate interactive prompts.

**Problem:**
Even with checks in place, Convex CLI was still prompting for input in Conductor's non-interactive terminal.

**Solution:**
- Remove all Convex codegen logic from `conductor-run.sh`
- Dev servers start immediately without Convex prompts
- Users can run `bun run convex:dev` separately if they need Convex backend

**Result:**
✅ No more interactive prompts
✅ Clean startup in Conductor
✅ App runs (without backend database functionality unless Convex is configured separately)

## Test plan
- [x] Run conductor-run.sh - no prompts
- [x] Dev servers start successfully
- [x] No Convex CLI interaction required

🤖 Generated with [Claude Code](https://claude.com/claude-code)