### PR TITLE
fix: remove overflow-hidden from chat feed to enable scrolling

### DIFF
--- a/apps/web/src/components/chat-room.tsx
+++ b/apps/web/src/components/chat-room.tsx
@@ -863,7 +863,7 @@ function ChatRoom({ chatId, initialMessages }: ChatRoomProps) {
         initialMessages={normalizedInitial}
         optimisticMessages={messages}
         paddingBottom={conversationPaddingBottom}
-        className="flex-1 rounded-xl bg-background/40 shadow-inner overflow-hidden"
+        className="flex-1 rounded-xl bg-background/40 shadow-inner"
         isStreaming={status === "streaming"}
         userId={convexUserId as string | null}
       />


### PR DESCRIPTION
## Summary
- Fixed scrolling issue in chat messages by removing the `overflow-hidden` class from ChatMessagesFeed container
- The scroll functionality is implemented using Radix UI's ScrollArea inside ChatMessagesPanel
- The parent `overflow-hidden` was preventing the scroll viewport from functioning properly

## Changes
- `apps/web/src/components/chat-room.tsx`: Removed `overflow-hidden` from line 866

Fixes #343

🤖 Generated with [Claude Code](https://claude.ai/code)