### PR TITLE
fix: remove overflow-hidden from chat page container to enable scrolling

### DIFF
--- a/apps/web/src/app/dashboard/chat/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/chat/[id]/page.tsx
@@ -37,7 +37,7 @@ export default async function ChatPage({ params }: { params: Promise<{ id: strin
 		});
 
 		return (
-			<div className="mx-auto flex h-full w-full max-w-5xl flex-1 flex-col gap-0 overflow-hidden min-h-0">
+			<div className="mx-auto flex h-full w-full max-w-5xl flex-1 flex-col gap-0 min-h-0">
 				<ChatRoomClient chatId={chatIdParam} initialMessages={initialMessages} />
 			</div>
 		);


### PR DESCRIPTION
The previous fix removed overflow-hidden from ChatMessagesFeed, but the actual issue was with the parent container in the chat page. The overflow-hidden on the page container was preventing the Radix UI ScrollArea viewport from establishing its own scrollable context.

This fix removes overflow-hidden from the chat page container while keeping the min-h-0 and flex properties that are necessary for proper layout. The ScrollArea component inside ChatMessagesPanel already handles overflow with its own viewport.

Fixes #345

🤖 Generated with [Claude Code](https://claude.ai/code)