### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/apps/server/convex/migrations.ts
+++ b/apps/server/convex/migrations.ts
@@ -372,13 +372,14 @@ export const removeOnboardingFields = internalMutation({
 									);
 								} else {
 									// Remove onboarding fields by setting them to undefined
+									// Type assertion needed because these fields are deprecated and no longer in schema
 									await ctx.db.patch(user._id, {
 										onboardingCompletedAt: undefined,
 										displayName: undefined,
 										preferredTone: undefined,
 										customInstructions: undefined,
 										updatedAt: Date.now(),
-									});
+									} as any);
 									console.log(
 										`[Migration] Removed onboarding fields from user ${user._id}`
 									);

--- a/apps/web/src/app/openrouter/callback/page.tsx
+++ b/apps/web/src/app/openrouter/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useConvex } from "convex/react";
 import { authClient } from "@/lib/auth-client";
@@ -15,7 +15,7 @@ import { saveOpenRouterKey } from "@/lib/openrouter-key-storage";
 import { logError } from "@/lib/logger";
 import { Logo } from "@/components/logo";
 
-export default function OpenRouterCallbackPage() {
+function OpenRouterCallbackContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const convex = useConvex();
@@ -97,7 +97,7 @@ export default function OpenRouterCallbackPage() {
     <div className="flex min-h-screen items-center justify-center p-6">
       <div className="w-full max-w-md space-y-6 text-center">
         <div className="flex justify-center">
-          <Logo size="medium" />
+          <Logo size="large" />
         </div>
 
         {status === "processing" && (
@@ -177,5 +177,22 @@ export default function OpenRouterCallbackPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function OpenRouterCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <div className="w-full max-w-md space-y-6 text-center">
+          <div className="flex justify-center">
+            <Logo size="large" />
+          </div>
+          <div className="text-sm text-muted-foreground">Loading...</div>
+        </div>
+      </div>
+    }>
+      <OpenRouterCallbackContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -51,12 +51,12 @@ export function Sidebar({ className, children, defaultCollapsed = false, ...prop
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if ((e.metaKey || e.ctrlKey) && e.key === "b") {
 				e.preventDefault();
-				setCollapsed((prev) => !prev);
+				setCollapsed(!collapsed);
 			}
 		};
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [setCollapsed]);
+	}, [collapsed, setCollapsed]);
 
 	const contextValue = React.useMemo(
 		() => ({ collapsed, setCollapsed }),


### PR DESCRIPTION
## Fixes

This PR resolves all TypeScript build errors from the previous OAuth implementation:

1. **Migration type assertion** - Added  to allow patching deprecated fields that no longer exist in schema
2. **Logo component** - Fixed size prop from 'medium' to 'large' 
3. **Sidebar toggle** - Fixed setCollapsed to handle boolean toggle correctly
4. **Suspense boundary** - Wrapped OpenRouter callback page in Suspense for useSearchParams()

## Testing

✅ Local build successful
✅ All TypeScript errors resolved
✅ No runtime errors

## Related

Fixes build failures from #348