### PR TITLE
fix: update Vercel build config to build web app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-	"buildCommand": "bun run build",
-	"outputDirectory": ".next",
+	"buildCommand": "bun run build:web",
+	"outputDirectory": "apps/web/.next",
 	"installCommand": "bun install"
 }


### PR DESCRIPTION
## Problem

The model selector was missing from production (osschat.dev) because Vercel deployments were failing.

## Root Cause

The `vercel.json` was configured to run `bun run build`, which only builds the **server** (Convex backend), not the **web** frontend.

From `package.json`:
- `build`: `turbo -F server build` ❌ (server only)
- `build:web`: `turbo -F web build` ✅ (web app)

## Solution

Updated `vercel.json`:
- `buildCommand`: `bun run build` → `bun run build:web`
- `outputDirectory`: `.next` → `apps/web/.next` (monorepo structure)

## Testing

✅ Local build succeeds: `bunx next build`
✅ Vercel should now build and deploy successfully

## Impact

Once merged, the model selector will appear in production after Vercel successfully deploys.