### PR TITLE
fix: correct Vercel build command for apps/web root directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-	"buildCommand": "bun run build:web",
-	"outputDirectory": "apps/web/.next",
+	"buildCommand": "bun run build",
+	"outputDirectory": ".next",
 	"installCommand": "bun install"
 }


### PR DESCRIPTION
## Problem

PR #353 was merged but only the first commit was squashed, leaving an incorrect build command.

## Root Cause

Vercel Root Directory is set to `apps/web`, so when the build runs, it's already in that directory. The command `bun run build:web` doesn't exist in `apps/web/package.json` - only `bun run build` exists there.

## Solution

Update `vercel.json`:
- `buildCommand`: `bun run build:web` → `bun run build` 
- `outputDirectory`: `apps/web/.next` → `.next` (relative to apps/web)

This matches the Vercel dashboard configuration where Root Directory is `apps/web`.

## Testing

✅ Local build works: `cd apps/web && bun run build`
✅ Vercel will now build successfully with this configuration