### PR TITLE
fix: remove vercel.json to use Vercel dashboard config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-	"buildCommand": "bun run build",
-	"outputDirectory": ".next",
-	"installCommand": "bun install"
-}


### PR DESCRIPTION
Removes vercel.json to allow Vercel to use the dashboard configuration for builds. The presence of vercel.json was overriding the dashboard settings and causing build failures.