### PR TITLE
fix: configure vercel.json for monorepo root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-	"buildCommand": "bun run build",
-	"outputDirectory": ".next",
-	"installCommand": "bun install"
+  "buildCommand": "bun run build:web",
+  "outputDirectory": "apps/web/.next"
 }


### PR DESCRIPTION
This change configures vercel.json to build the web application from the monorepo root. \n\n**IMPORTANT**: For this to work, you must change the 'Root Directory' setting in your Vercel project's dashboard back to the repository root (i.e., leave it blank).