### PR TITLE
fix: use npm for Vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
-  "buildCommand": "bun run build:web",
+  "installCommand": "npm install",
+  "buildCommand": "npm run build:web",
   "outputDirectory": "apps/web/.next"
 }


### PR DESCRIPTION
This is a test to see if using npm instead of bun for the Vercel build resolves the 'script not found' error.