### PR TITLE
fix: use direct build command for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "npm install",
-  "buildCommand": "npm run build:web",
+  "installCommand": "bun install",
+  "buildCommand": "cd apps/web && bun run build",
   "outputDirectory": "apps/web/.next"
 }


### PR DESCRIPTION
This attempts to fix the Vercel build by using a more direct build command, avoiding turbo.