### PR TITLE
fix: model selector button always shows content

### DIFF
--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -423,15 +423,15 @@ function ModelSelector({ options, value, onChange, disabled, loading }: ModelSel
 				<Button
 					variant="outline"
 					disabled={disabled || loading || options.length === 0}
-					className="w-[200px] justify-between"
+					className="w-[200px] justify-between gap-2"
 				>
-					{selectedProvider && (
-						<ModelSelectorLogo provider={selectedProvider} className="size-4" />
-					)}
-					{selectedOption && (
-						<ModelSelectorName>{triggerLabel}</ModelSelectorName>
-					)}
-					<Check className="ml-2 size-4 shrink-0 opacity-50" />
+					<div className="flex items-center gap-2 flex-1 min-w-0">
+						{selectedProvider && (
+							<ModelSelectorLogo provider={selectedProvider} className="size-4 shrink-0" />
+						)}
+						<ModelSelectorName className="truncate">{triggerLabel}</ModelSelectorName>
+					</div>
+					<Settings className="size-4 shrink-0 opacity-50" />
 				</Button>
 			</ModelSelectorTrigger>
 			<ModelSelectorContent>


### PR DESCRIPTION
## Summary
Fixes the model selector button that wasn't displaying correctly.

## Changes
- Removed conditional rendering of `ModelSelectorName` - now always shows the trigger label
- Wrapped button content in flex container for consistent layout
- Changed icon from `Check` to `Settings` for better semantics
- Added `truncate` class to prevent text overflow
- Added `gap-2` for consistent spacing

## Problem
The button was conditionally rendering content with `{selectedOption && ...}`, causing it to appear broken when no model was initially selected or during loading states.

## Solution
Always render the `ModelSelectorName` with the `triggerLabel`, which already handles all states (loading, no selection, etc.)

## Test plan
- [x] Model selector button displays correctly on initial page load
- [x] Button shows "Select model" when no model is selected
- [x] Button shows "Loading models..." during loading
- [x] Button shows selected model name when a model is chosen

🤖 Generated with [Claude Code](https://claude.com/claude-code)