### PR TITLE
fix: improve model selector OAuth UX

### DIFF
--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -431,7 +431,7 @@ function ModelSelector({ options, value, onChange, disabled, loading }: ModelSel
 						)}
 						<ModelSelectorName className="truncate">{triggerLabel}</ModelSelectorName>
 					</div>
-					<Settings className="size-4 shrink-0 opacity-50" />
+					{!hasKey && !isKeyLoading && <Settings className="size-4 shrink-0 opacity-50" />}
 				</Button>
 			</ModelSelectorTrigger>
 			<ModelSelectorContent>


### PR DESCRIPTION
## Summary
Improves the model selector user experience by hiding the Settings icon when the user already has an OpenRouter API key connected.

## Problem
The Settings icon was always visible, even when the user already had an API key connected. This was confusing because:
- The icon wasn't doing anything useful when already connected
- It cluttered the UI unnecessarily
- Users had to discover the OAuth flow by trial and error

## Solution
- Conditionally show Settings icon only when user doesn't have an API key (`!hasKey && !isKeyLoading`)
- The OpenRouter sign-in banner is already shown in the dropdown when no key is present, making it easy to connect
- Once connected, the UI is cleaner with just the model selector

## Changes
- Hide Settings icon when `hasKey` is true
- Keep the OpenRouterSignInBanner visible in dropdown for users without keys

## Test plan
- [x] Settings icon appears when no API key is connected
- [x] Settings icon disappears once user has API key
- [x] OAuth sign-in banner appears in dropdown when no key
- [x] Model selector works normally when key is connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)