### PR TITLE
fix: add .next to root gitignore to prevent build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.next
 .turbo
 .alchemy
 .env


### PR DESCRIPTION
## Summary
- Add `.next` to root `.gitignore` to prevent Next.js build artifacts from being tracked anywhere in the monorepo
- Remove stray `apps/server/.next/` folder that appeared during recent Vercel build troubleshooting

## Problem
During recent Vercel deployment fixes, `.next/` build artifacts appeared in `apps/server/` directory and were showing as untracked files. While `apps/web/.gitignore` already ignores `/.next/` for the web app, the root gitignore should also include `.next` to catch any stray build artifacts throughout the monorepo.

## Solution
- Added `.next` to root `.gitignore` (line 2)
- This prevents build artifacts from being tracked anywhere in the repository

## Test Plan
- [x] Verified `.next` is in root `.gitignore`
- [x] Confirmed `apps/server/.next/` no longer appears in git status
- [x] Build artifacts will be ignored project-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)