### PR TITLE
feat: improve OpenRouter OAuth UX and add keyboard shortcut

### DIFF
--- a/apps/web/src/components/chat-composer.tsx
+++ b/apps/web/src/components/chat-composer.tsx
@@ -226,6 +226,9 @@ function ChatComposer({
     () => externalReasoningConfig ?? DEFAULT_REASONING_CONFIG
   );
 
+  // Model selector open state for keyboard shortcut
+  const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
+
   const { textareaRef, adjustHeight, debouncedAdjustHeight } =
     useAutoResizeTextarea({ minHeight: 60, maxHeight: 200 });
   const activeModelIdRef = useRef<string>("");
@@ -300,6 +303,20 @@ function ChatComposer({
       adjustHeight();
     }
   }, [initialValue, adjustHeight, textareaRef]);
+
+  // Keyboard shortcut: Cmd+M / Ctrl+M to open model selector
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check for Cmd+M (Mac) or Ctrl+M (Windows/Linux)
+      if ((e.metaKey || e.ctrlKey) && e.key === 'm') {
+        e.preventDefault();
+        setModelSelectorOpen(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   // File upload handler
   const handleFileSelect = useCallback(
@@ -572,6 +589,8 @@ function ChatComposer({
             }}
             disabled={disabled || isBusy || modelOptions.length === 0}
             loading={modelsLoading}
+            open={modelSelectorOpen}
+            onOpenChange={setModelSelectorOpen}
           />
           {userId && chatId && (
             <FileUploadButton

--- a/apps/web/src/components/settings-page-client.tsx
+++ b/apps/web/src/components/settings-page-client.tsx
@@ -48,9 +48,9 @@ export default function SettingsPageClient() {
 
         <section className="rounded-xl border p-4 space-y-3">
           <div>
-            <h2 className="text-sm font-medium">OpenRouter API</h2>
+            <h2 className="text-sm font-medium">OpenRouter Connection</h2>
             <p className="text-muted-foreground mt-1 text-sm">
-              Connect your OpenRouter account to access AI models. You can use OAuth (recommended) or manually enter your API key.
+              Connect your OpenRouter account via OAuth to access AI models.
             </p>
           </div>
           {!isLoading && (

--- a/apps/web/src/components/settings/api-key-section-with-oauth.tsx
+++ b/apps/web/src/components/settings/api-key-section-with-oauth.tsx
@@ -1,26 +1,20 @@
 "use client";
 
 /**
- * Enhanced API Key Section with OAuth Support
+ * OpenRouter OAuth Connection Section
  *
- * This component demonstrates how to integrate the OpenRouter OAuth flow
- * alongside the manual API key entry. Users can choose to either:
- * 1. Connect via OAuth (recommended - more secure, easier)
- * 2. Manually enter their API key (advanced users)
- *
- * Usage:
- * Replace the existing ApiKeySection component with this one to add OAuth support.
+ * This component handles OpenRouter OAuth connection.
+ * Users can connect their OpenRouter account via OAuth for secure, easy access.
  */
 
-import { useState, type FormEvent } from "react";
+import { useState } from "react";
 import { Loader2 } from "@/lib/icons";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { captureClientEvent, registerClientProperties } from "@/lib/posthog";
 import { logError } from "@/lib/logger";
-import { spacing, iconSize } from "@/styles/design-tokens";
+import { iconSize } from "@/styles/design-tokens";
 import { useOpenRouterOAuth } from "@/hooks/use-openrouter-oauth";
 import { useOpenRouterKey } from "@/hooks/use-openrouter-key";
 
@@ -33,68 +27,32 @@ export function ApiKeySectionWithOAuth({
   hasStoredKey,
   onKeyChanged,
 }: ApiKeySectionWithOAuthProps) {
-  const [apiKeyInput, setApiKeyInput] = useState("");
-  const [savingKey, setSavingKey] = useState(false);
-  const [removingKey, setRemovingKey] = useState(false);
-  const [apiKeyError, setApiKeyError] = useState<string | null>(null);
-  const [showManualEntry, setShowManualEntry] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
 
   // OAuth hook
   const { initiateLogin, isLoading: isOAuthLoading, error: oauthError } = useOpenRouterOAuth();
 
   // Key management hook
-  const { saveKey, removeKey } = useOpenRouterKey();
+  const { removeKey } = useOpenRouterKey();
 
-  async function handleSaveApiKey(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (savingKey) return;
-    const trimmed = apiKeyInput.trim();
-    if (trimmed.length < 10) {
-      setApiKeyError("Enter a valid OpenRouter key (sk-or-v1…).");
-      return;
-    }
-    setSavingKey(true);
-    setApiKeyError(null);
-    try {
-      await saveKey(trimmed);
-      setApiKeyInput("");
-      toast.success("OpenRouter key saved");
-      captureClientEvent("openrouter.key_saved", {
-        source: "settings_manual",
-        masked_tail: trimmed.slice(-4),
-        scope: "workspace",
-      });
-      registerClientProperties({ has_openrouter_key: true });
-      onKeyChanged();
-    } catch (error) {
-      logError("Failed to save OpenRouter key", error);
-      setApiKeyError("Failed to save OpenRouter key.");
-      toast.error("Failed to save OpenRouter key");
-    } finally {
-      setSavingKey(false);
-    }
-  }
-
-  async function handleRemoveApiKey() {
-    if (removingKey) return;
+  async function handleDisconnect() {
+    if (disconnecting) return;
     const wasLinked = hasStoredKey;
-    setRemovingKey(true);
+    setDisconnecting(true);
     try {
       await removeKey();
-      setApiKeyInput("");
-      setApiKeyError(null);
-      toast.success("OpenRouter key removed");
-      captureClientEvent("openrouter.key_removed", {
+      toast.success("OpenRouter account disconnected");
+      captureClientEvent("openrouter.disconnected", {
         source: "settings",
         had_models_cached: wasLinked,
       });
       registerClientProperties({ has_openrouter_key: false });
       onKeyChanged();
     } catch (error) {
-      logError("Failed to remove OpenRouter key", error);
-      toast.error("Failed to remove OpenRouter key");
+      logError("Failed to disconnect OpenRouter account", error);
+      toast.error("Failed to disconnect OpenRouter account");
     } finally {
-      setRemovingKey(false);
+      setDisconnecting(false);
     }
   }
 
@@ -107,11 +65,11 @@ export function ApiKeySectionWithOAuth({
 
   return (
     <div className="rounded-lg border bg-muted/40 p-4 space-y-3">
-      <div className={cn("flex items-start justify-between", spacing.gap.sm)}>
+      <div className="flex items-start justify-between gap-2">
         <div>
-          <p className="text-sm font-medium">OpenRouter API key</p>
+          <p className="text-sm font-medium">OpenRouter OAuth</p>
           <p className="text-xs text-muted-foreground">
-            Connect your personal key so OpenChat can call OpenRouter models for you.
+            Connect your OpenRouter account to access AI models.
           </p>
         </div>
         <span
@@ -120,7 +78,7 @@ export function ApiKeySectionWithOAuth({
             hasStoredKey ? "text-emerald-600" : "text-destructive"
           )}
         >
-          {hasStoredKey ? "Key stored" : "Not set"}
+          {hasStoredKey ? "Connected" : "Not connected"}
         </span>
       </div>
 
@@ -131,145 +89,46 @@ export function ApiKeySectionWithOAuth({
         </p>
       )}
 
-      {/* API Key Error Display */}
-      {apiKeyError && (
-        <p
-          id="settings-api-key-error"
-          className="text-xs font-medium text-destructive"
-          role="alert"
+      {!hasStoredKey ? (
+        <Button
+          type="button"
+          onClick={handleOAuthConnect}
+          disabled={isOAuthLoading}
+          className="w-full"
+          size="default"
         >
-          {apiKeyError}
-        </p>
-      )}
-
-      {!hasStoredKey && !showManualEntry && (
-        <div className="space-y-2">
-          {/* OAuth Connect Button (Primary Option) */}
-          <Button
-            type="button"
-            onClick={handleOAuthConnect}
-            disabled={isOAuthLoading}
-            className="w-full"
-            size="default"
-          >
-            {isOAuthLoading ? (
-              <Loader2
-                className={cn("mr-2 animate-spin", iconSize.sm)}
-                aria-hidden="true"
-              />
-            ) : null}
-            Connect with OpenRouter OAuth
-          </Button>
-
-          {/* Divider */}
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-muted/40 px-2 text-muted-foreground">
-                Or
-              </span>
-            </div>
-          </div>
-
-          {/* Manual Entry Button */}
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setShowManualEntry(true)}
-            className="w-full"
-            size="sm"
-          >
-            Enter API key manually
-          </Button>
-        </div>
-      )}
-
-      {/* Manual API Key Entry Form */}
-      {(!hasStoredKey && showManualEntry) || hasStoredKey ? (
-        <>
-          <form
-            className={cn("flex flex-col sm:flex-row", spacing.gap.sm)}
-            onSubmit={handleSaveApiKey}
-          >
-            <Input
-              value={apiKeyInput}
-              onChange={(event) => {
-                setApiKeyInput(event.target.value);
-                if (apiKeyError) setApiKeyError(null);
-              }}
-              type="password"
-              placeholder="sk-or-v1..."
-              autoComplete="off"
-              required
-              className="font-mono"
-              aria-label="OpenRouter API key"
-              aria-invalid={!!apiKeyError}
-              aria-describedby={
-                apiKeyError ? "settings-api-key-error" : undefined
-              }
+          {isOAuthLoading ? (
+            <Loader2
+              className={cn("mr-2 animate-spin", iconSize.sm)}
+              aria-hidden="true"
             />
-            <Button
-              type="submit"
-              disabled={savingKey || apiKeyInput.trim().length < 10}
-              className="sm:w-auto"
-              aria-busy={savingKey}
-            >
-              {savingKey ? (
-                <Loader2
-                  className={cn("mr-2 animate-spin", iconSize.sm)}
-                  aria-hidden="true"
-                />
-              ) : null}
-              {hasStoredKey ? "Replace key" : "Save key"}
-            </Button>
-          </form>
-
-          {!hasStoredKey && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowManualEntry(false)}
-              className="text-xs"
-            >
-              Use OAuth instead
-            </Button>
-          )}
-        </>
-      ) : null}
-
-      <div
-        className={cn(
-          "flex flex-wrap items-center justify-between text-xs text-muted-foreground",
-          spacing.gap.sm
-        )}
-      >
-        <p>
-          Keys are encrypted in your browser before being stored in your account
-          database and synced across devices. Once stored, keys cannot be viewed.
-        </p>
-        {hasStoredKey ? (
+          ) : null}
+          Connect with OpenRouter
+        </Button>
+      ) : (
+        <div className="flex flex-wrap items-center justify-between text-xs text-muted-foreground gap-2">
+          <p>
+            Your OpenRouter account is connected and encrypted in your browser before being stored.
+          </p>
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            onClick={handleRemoveApiKey}
-            disabled={removingKey}
-            aria-label="Remove OpenRouter API key"
-            aria-busy={removingKey}
+            onClick={handleDisconnect}
+            disabled={disconnecting}
+            aria-label="Disconnect OpenRouter account"
+            aria-busy={disconnecting}
           >
-            {removingKey ? (
+            {disconnecting ? (
               <Loader2
                 className={cn("mr-1 animate-spin", iconSize.xs)}
                 aria-hidden="true"
               />
             ) : null}
-            Remove key
+            Disconnect
           </Button>
-        ) : null}
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Major UX improvements to OpenRouter OAuth integration and model selector:

### Model Selector
- **When no account connected:** Shows a clean "Connect OpenRouter" button that directly triggers OAuth (no dropdown)
- **After connection:** Shows normal model selector with full model list
- **Removed:** Settings icon (no longer needed with OAuth-first approach)
- **Keyboard shortcut:** Press Cmd+M (Mac) or Ctrl+M (Windows/Linux) to open model selector

### Settings Page  
- **OAuth-only flow:** Removed manual API key input option completely
- **Simplified UI:** Only shows OAuth connection button when not connected
- **Better labeling:** Changed "Remove key" → "Disconnect" button
- **Updated copy:** Section titled "OpenRouter Connection" instead of "OpenRouter API"

## Problem
The previous UX had several pain points:
1. Model selector showed "Select model" when no account was connected (confusing)
2. Users had to navigate to Settings to connect via OAuth
3. Manual API key input option added complexity for most users
4. No keyboard shortcut for power users
5. "Remove key" terminology was technical/unclear

## Solution
**OAuth-First Approach:**
- Made OAuth the primary (and only) connection method
- Model selector button becomes the OAuth trigger when not connected
- One-click connection from anywhere the model selector appears

**Keyboard Accessibility:**
- Cmd+M / Ctrl+M opens model selector in chat and dashboard
- Supports controlled `open` state for the ModelSelector component

**Cleaner Settings:**
- Removed manual key input complexity
- Clear "Disconnect" action instead of "Remove key"
- Simplified messaging focused on OAuth benefits

## Technical Changes

### apps/web/src/components/model-selector.tsx
- Added `open` and `onOpenChange` props for controlled mode
- Renders "Connect OpenRouter" button when `!hasKey`
- Removed Settings icon
- Removed sign-in banner from dropdown (no longer needed)

### apps/web/src/components/settings/api-key-section-with-oauth.tsx
- Removed manual API key input completely
- Simplified to OAuth button + disconnect option only
- Changed "Remove key" → "Disconnect"
- Updated all copy to reflect OAuth-only approach

### apps/web/src/components/settings-page-client.tsx  
- Updated section title: "OpenRouter API" → "OpenRouter Connection"
- Updated description to reflect OAuth-only flow

### apps/web/src/components/chat-composer.tsx
- Added `modelSelectorOpen` state for keyboard shortcut control
- Added keyboard listener for Cmd+M / Ctrl+M
- Passes `open` and `onOpenChange` to ModelSelector

## Test Plan
- [x] When not connected: Model selector shows "Connect OpenRouter" button
- [x] Clicking button triggers OAuth flow
- [x] After OAuth: Model selector shows full model list
- [x] Settings page only shows OAuth option (no manual key input)
- [x] "Disconnect" button works and returns to "Connect" state
- [x] Cmd+M / Ctrl+M opens model selector in chat
- [x] Model selector state syncs across all instances after disconnect

## User Impact
✅ **Simpler onboarding** - One button to connect
✅ **Better discoverability** - OAuth accessible from model selector 
✅ **Clearer actions** - "Disconnect" vs "Remove key"
✅ **Power user support** - Keyboard shortcut for quick model switching
✅ **Reduced complexity** - No manual key management

🤖 Generated with [Claude Code](https://claude.com/claude-code)