### PR TITLE
fix: force HTTPS for React Grab and add missing CSP entries

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -98,6 +98,8 @@ const nextConfig = {
 		if (!isProd) {
 			scriptSrcSet.add("https://unpkg.com");
 		}
+		// Add Vercel Speed Insights
+		scriptSrcSet.add("https://va.vercel-scripts.com");
 		for (const origin of additionalConnect) {
 			if (origin) {
 				scriptSrcSet.add(origin);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -136,7 +136,7 @@ export default function RootLayout({
 				{/* React Grab - Developer tool for element inspection */}
 				{process.env.NODE_ENV === "development" && (
 					<Script
-						src="//unpkg.com/react-grab/dist/index.global.js"
+						src="https://unpkg.com/react-grab/dist/index.global.js"
 						crossOrigin="anonymous"
 						strategy="beforeInteractive"
 						data-enabled="true"

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -9,7 +9,7 @@ import { SECURE_SESSION_COOKIE_NAME, NORMAL_SESSION_COOKIE_NAME } from "@/lib/ap
  */
 const BASE_CSP_DIRECTIVES = [
 	"default-src 'self'",
-	"script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.convex.cloud https://*.convex.site https://us.i.posthog.com https://unpkg.com",
+	"script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.convex.cloud https://*.convex.site https://us.i.posthog.com https://us-assets.i.posthog.com https://unpkg.com https://va.vercel-scripts.com",
 	"connect-src 'self' https://*.convex.cloud https://*.convex.site wss://*.convex.cloud wss://*.convex.site https://openrouter.ai https://us.i.posthog.com https://us-assets.i.posthog.com",
 	"img-src 'self' blob: data: https://*.convex.cloud https://*.convex.site https://avatar.vercel.sh https://avatars.githubusercontent.com https://models.dev",
 	"font-src 'self' data:",


### PR DESCRIPTION
## Summary

Quick hotfix to resolve CSP blocking issues preventing React Grab and other development tools from loading.

## Problem

React Grab was still being blocked by CSP with this error:
```
Loading the script 'http://unpkg.com/react-grab/dist/index.global.js' violates CSP directive
```

The protocol-relative URL `//unpkg.com` was resolving to `http://` in local development, but the CSP only allows `https://unpkg.com`.

## Changes

### 1. Force HTTPS for React Grab (`layout.tsx`)
- Changed from `//unpkg.com` → `https://unpkg.com`
- Ensures script always loads over HTTPS, matching CSP requirements

### 2. Add Missing CSP Entries (`middleware.ts`)
- Added `https://us-assets.i.posthog.com` (PostHog assets)
- Added `https://va.vercel-scripts.com` (Vercel Speed Insights)

### 3. Add Vercel Speed Insights to Production CSP (`next.config.mjs`)
- Added `https://va.vercel-scripts.com` to scriptSrcSet

## Testing

- [x] React Grab now loads without CSP errors
- [x] PostHog assets load correctly
- [x] Vercel Speed Insights loads correctly
- [x] No CSP violations in console

## Files Changed

- `apps/web/src/app/layout.tsx` - Force HTTPS for React Grab
- `apps/web/src/middleware.ts` - Add PostHog and Vercel to CSP
- `apps/web/next.config.mjs` - Add Vercel to production CSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)