### PR TITLE
fix: add generated types for rate limiter component

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as http from "../http.js";
 import type * as lib_batchFileUrls from "../lib/batchFileUrls.js";
 import type * as lib_dbStats from "../lib/dbStats.js";
 import type * as lib_logger from "../lib/logger.js";
+import type * as lib_rateLimiter from "../lib/rateLimiter.js";
 import type * as messages from "../messages.js";
 import type * as migrations from "../migrations.js";
 import type * as previewSeed from "../previewSeed.js";
@@ -40,6 +41,7 @@ declare const fullApi: ApiFromModules<{
   "lib/batchFileUrls": typeof lib_batchFileUrls;
   "lib/dbStats": typeof lib_dbStats;
   "lib/logger": typeof lib_logger;
+  "lib/rateLimiter": typeof lib_rateLimiter;
   messages: typeof messages;
   migrations: typeof migrations;
   previewSeed: typeof previewSeed;
@@ -2170,6 +2172,140 @@ export declare const components: {
       findOne: FunctionReference<"query", "internal", any, any>;
       update: FunctionReference<"mutation", "internal", any, any>;
       updateMany: FunctionReference<"mutation", "internal", any, any>;
+    };
+  };
+  rateLimiter: {
+    lib: {
+      checkRateLimit: FunctionReference<
+        "query",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          count?: number;
+          key?: string;
+          name: string;
+          reserve?: boolean;
+          throws?: boolean;
+        },
+        { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getServerTime: FunctionReference<"mutation", "internal", {}, number>;
+      getValue: FunctionReference<
+        "query",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          key?: string;
+          name: string;
+          sampleShards?: number;
+        },
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          shard: number;
+          ts: number;
+          value: number;
+        }
+      >;
+      rateLimit: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          count?: number;
+          key?: string;
+          name: string;
+          reserve?: boolean;
+          throws?: boolean;
+        },
+        { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
+      >;
+      resetRateLimit: FunctionReference<
+        "mutation",
+        "internal",
+        { key?: string; name: string },
+        null
+      >;
+    };
+    time: {
+      getServerTime: FunctionReference<"mutation", "internal", {}, number>;
     };
   };
 };


### PR DESCRIPTION
## Problem
The Vercel build failed with:
```
Type error: Property 'rateLimiter' does not exist on type components
Command "turbo run build" exited with 1
```

## Root Cause
PR #371 added the `@convex-dev/rate-limiter` component to `convex.config.ts` but didn't regenerate the TypeScript types. The `_generated/api.d.ts` file was missing the `rateLimiter` property in the `components` type.

## Solution
Ran `npx convex codegen` to regenerate the TypeScript definitions with the rate limiter component included.

## Testing
✅ Build tested locally with `bun run build` - passes successfully
✅ TypeScript compilation works
✅ All rate limiter functionality intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)