### PR TITLE
fix(test): update vitest config and fix chat route test

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "apps/web/src"),
+			"@server": path.resolve(__dirname, "apps/server"),
 		},
 	},
 	root: process.cwd(),


### PR DESCRIPTION
Fixed vitest alias for @server and updated chat-route.spec.ts to mock dependencies and match implementation.