### PR TITLE
fix(conductor): use local Convex deployments to prevent schema conflicts

### DIFF
--- a/conductor-run.sh
+++ b/conductor-run.sh
@@ -2,9 +2,9 @@
 
 echo "Starting OpenChat for Conductor..."
 echo ""
-echo "⚠️  Note: Skipping Convex codegen for Conductor"
-echo "   The app will run without backend database functionality"
-echo "   To use Convex, run 'bun run convex:dev' separately"
+echo "✅ Using LOCAL Convex deployment for this worktree"
+echo "   Your changes won't affect the main project's database"
+echo "   Each worktree has its own isolated Convex backend"
 echo ""
 
 echo "Starting dev servers..."

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -62,14 +62,23 @@ if [ -f "$CONDUCTOR_ROOT_PATH/.env.local" ]; then
     echo "✅ Copied root .env.local"
 fi
 
-# Set up Convex
+# Set up Convex for local deployment
 echo ""
-if [ -f "apps/server/.env.local" ] && grep -q "CONVEX_DEPLOYMENT" apps/server/.env.local; then
-    echo "✅ Convex configuration found in apps/server/.env.local"
-    echo "   Your worktree will use the same Convex deployment as the main project"
+echo "Configuring Convex to use local deployment..."
+
+# Modify server package.json to use local Convex deployment
+if [ -f "apps/server/package.json" ]; then
+    # Use Node.js to safely modify the JSON file
+    node -e "
+        const fs = require('fs');
+        const pkg = JSON.parse(fs.readFileSync('apps/server/package.json', 'utf8'));
+        pkg.scripts.dev = 'convex dev --local';
+        fs.writeFileSync('apps/server/package.json', JSON.stringify(pkg, null, 2) + '\n');
+    "
+    echo "✅ Configured Convex to use local deployment (isolated from main project)"
+    echo "   Your worktree has its own Convex backend - schema changes won't conflict!"
 else
-    echo "⚠️  No Convex configuration found"
-    echo "   Convex will prompt you to select a project when you run 'convex dev'"
+    echo "⚠️  Could not find apps/server/package.json"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
Updated Conductor worktree configuration to use **isolated local Convex deployments** instead of sharing the main project's cloud deployment. This prevents schema conflicts when working on multiple features simultaneously in different worktrees.

## Problem
Previously, when creating multiple Conductor worktrees, they all shared the same `dev:sincere-woodpecker-479` Convex deployment. This caused conflicts when:
- Multiple worktrees had different schema changes
- One worktree's schema update broke another worktree
- Developers couldn't work on independent features safely

## Solution
Each Conductor worktree now gets its own **local Convex deployment** with isolated data:

### Changes
- ✅ Modified `conductor-setup.sh` to patch `server/package.json` dev script
- ✅ Changed `convex dev` → `convex dev --local` for worktrees
- ✅ Updated `conductor-run.sh` messaging to reflect local deployment
- ✅ Each worktree has isolated Convex backend (state in `~/.convex/`)

### Benefits
- ✅ **No schema conflicts** between worktrees
- ✅ **No CLI prompts** for project selection
- ✅ **Completely isolated** data per worktree
- ✅ **Works offline**
- ✅ Still copies `.env.local` for auth and other config

## How It Works
1. Setup script copies `.env.local` files (for auth, etc.)
2. Setup script modifies `apps/server/package.json` to use `convex dev --local`
3. When you run the worktree, it starts a local Convex backend
4. Each worktree has its own database - no conflicts!

## Test plan
- [x] Validated bash script syntax
- [x] Tested Node.js JSON modification logic
- [x] Scripts properly configure local Convex deployment
- [x] Clear messaging about isolated deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)