### PR TITLE
fix: remove hardcoded Bun paths from convex test-setup

### DIFF
--- a/apps/server/convex/test-setup.ts
+++ b/apps/server/convex/test-setup.ts
@@ -46,14 +46,14 @@ const rateLimiterComponentSchema = defineSchema({
     }).index("name", ["name", "key", "shard"]),
 });
 
-// Rate limiter component modules (using absolute paths from the workspace root)
-// These paths go up 3 levels from convex/ to reach the workspace root
+// Rate limiter component modules (using proper package imports)
+// Import directly from the package without hardcoded paths
 const rateLimiterComponentModules = {
-  './internal.ts': () => import('../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+ea7eeb9bdd3f4abe/node_modules/@convex-dev/rate-limiter/dist/component/internal.js'),
-  './lib.ts': () => import('../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+ea7eeb9bdd3f4abe/node_modules/@convex-dev/rate-limiter/dist/component/lib.js'),
-  './schema.ts': () => import('../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+ea7eeb9bdd3f4abe/node_modules/@convex-dev/rate-limiter/dist/component/schema.js'),
-  './_generated/api.ts': () => import('../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+ea7eeb9bdd3f4abe/node_modules/@convex-dev/rate-limiter/dist/component/_generated/api.js'),
-  './_generated/server.ts': () => import('../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+ea7eeb9bdd3f4abe/node_modules/@convex-dev/rate-limiter/dist/component/_generated/server.js'),
+  './internal.ts': () => import('@convex-dev/rate-limiter/dist/component/internal.js'),
+  './lib.ts': () => import('@convex-dev/rate-limiter/dist/component/lib.js'),
+  './schema.ts': () => import('@convex-dev/rate-limiter/dist/component/schema.js'),
+  './_generated/api.ts': () => import('@convex-dev/rate-limiter/dist/component/_generated/api.js'),
+  './_generated/server.ts': () => import('@convex-dev/rate-limiter/dist/component/_generated/server.js'),
 };
 
 /**


### PR DESCRIPTION
## Summary
Fixes production Convex deployment failure caused by hardcoded Bun-specific paths with version hashes in test-setup file.

## Problem
Production deployments were failing with:
```
✘ [ERROR] Could not resolve "../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+ea7eeb9bdd3f4abe/node_modules/@convex-dev/rate-limiter/dist/component/internal.js"
```

The issue was in `apps/server/convex/test-setup.ts:52-56` which used:
- ❌ Hardcoded Bun-specific `.bun` directory structure
- ❌ Version-specific package hashes (`@0.3.0+ea7eeb9bdd3f4abe`)
- ❌ Absolute paths that don't exist in CI/production environments

## Root Cause
Commit [4ed542b](https://github.com/opentech1/openchat/commit/4ed542b) added comprehensive test suite but used hardcoded development paths that break in production. This has been causing deployment failures since that commit.

## Changes
- ✅ Replaced hardcoded paths with proper package imports
- ✅ Changed from `../../../node_modules/.bun/@convex-dev+rate-limiter@0.3.0+...` 
- ✅ To clean imports: `@convex-dev/rate-limiter/dist/component/*`
- ✅ Updated comments to reflect proper module resolution

## Impact
This enables:
- ✅ Convex deployments to succeed in CI/production
- ✅ Proper module resolution across all environments
- ✅ No hardcoded version hashes or environment-specific paths

## Testing
Local testing confirmed:
- ✅ **Build passes**: Next.js production build completes successfully
- ✅ **Type checking**: No TypeScript errors
- ✅ **Module resolution**: Imports use standard package resolution

## Related
- Related to PR #388 (jest-dom fix) - discovered during post-merge deployment verification
- Fixes issue that existed before PR #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)