### PR TITLE
fix: add crossDomain plugin for cross-origin auth

### DIFF
--- a/apps/server/convex/auth.ts
+++ b/apps/server/convex/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { convex } from "@convex-dev/better-auth/plugins";
+import { convex, crossDomain } from "@convex-dev/better-auth/plugins";
 import { createClient, type GenericCtx } from "@convex-dev/better-auth";
 import { components } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
@@ -65,6 +65,12 @@ export const createAuth = (
 		socialProviders,
 		plugins: [
 			convex(),
+			// Enable cross-domain authentication
+			// Required because Convex runs on .convex.site but app runs on osschat.dev
+			// This plugin allows cookies to be set across domains via one-time tokens
+			crossDomain({
+				siteUrl: siteUrl,
+			}),
 		],
 		trustedOrigins: [
 			"http://localhost:3000",

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/react";
-import { convexClient } from "@convex-dev/better-auth/client/plugins";
+import { convexClient, crossDomainClient } from "@convex-dev/better-auth/client/plugins";
 
 // Create auth client with Convex Better Auth
 // The convexClient plugin handles routing to /api/auth/[...all] which uses nextJsHandler()
@@ -7,5 +7,16 @@ import { convexClient } from "@convex-dev/better-auth/client/plugins";
 // Access env var directly to avoid build-time validation
 export const authClient = createAuthClient({
 	baseURL: process.env.NEXT_PUBLIC_APP_URL || "",
-	plugins: [convexClient()],
+	plugins: [
+		convexClient(),
+		// Enable cross-domain authentication
+		// Required because Convex runs on .convex.site but app runs on osschat.dev
+		// This plugin handles session storage and one-time token verification
+		crossDomainClient({
+			// Use localStorage for session persistence across page reloads
+			storage: typeof window !== "undefined" ? window.localStorage : undefined,
+			storagePrefix: "openchat",
+			disableCache: false,
+		}),
+	],
 });


### PR DESCRIPTION
## Summary

Fixes authentication issue where session cookies were not being set after OAuth callback.

- The root cause: Convex runs on `.convex.site` domain but the app runs on `osschat.dev`. Cookies cannot be set directly across domains.
- Solution: Added `crossDomain` plugin which uses one-time tokens (OTT) to establish sessions across domains.

### Changes

**Server-side (Convex):**
- Added `crossDomain` plugin to auth configuration
- Already deployed to Convex production

**Client-side (Next.js):**
- Added `crossDomainClient` plugin to auth client
- Configured localStorage for session persistence

## Test plan

- [ ] Click "Continue with GitHub" on sign-in page
- [ ] Verify redirect to dashboard after GitHub authorization
- [ ] Verify session persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)