### PR TITLE
fix: add auth callback page for OTT verification

### DIFF
--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
+import { NiceLoader } from "@/components/ui/nice-loader";
+
+/**
+ * Auth Callback Content Component
+ *
+ * Handles the one-time token (OTT) verification for cross-domain authentication.
+ * When OAuth completes, the user is redirected here with an OTT parameter.
+ * The crossDomainClient plugin automatically verifies the OTT and establishes the session.
+ * Once authenticated, the user is redirected to their intended destination.
+ */
+function AuthCallbackContent() {
+	const searchParams = useSearchParams();
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const verifyAndRedirect = async () => {
+			try {
+				// The crossDomainClient plugin should have already verified the OTT
+				// when this page loaded. Let's check if we have a session now.
+				const session = await authClient.getSession();
+
+				if (session?.data?.user) {
+					// Session established, redirect to dashboard
+					// Use window.location for dynamic redirect path from query param
+					const from = searchParams.get("from") || "/dashboard";
+					window.location.href = from;
+				} else {
+					// No session yet, the OTT might still be processing
+					// Wait a moment and check again
+					await new Promise((resolve) => setTimeout(resolve, 1000));
+
+					const retrySession = await authClient.getSession();
+					if (retrySession?.data?.user) {
+						const from = searchParams.get("from") || "/dashboard";
+						window.location.href = from;
+					} else {
+						// Still no session, something went wrong
+						setError("Authentication failed. Please try signing in again.");
+					}
+				}
+			} catch (err) {
+				console.error("[Auth Callback] Error:", err);
+				setError("An error occurred during authentication.");
+			}
+		};
+
+		verifyAndRedirect();
+	}, [searchParams]);
+
+	if (error) {
+		return (
+			<div className="min-h-screen flex items-center justify-center">
+				<div className="text-center space-y-4">
+					<p className="text-red-500">{error}</p>
+					<button
+						onClick={() => (window.location.href = "/auth/sign-in")}
+						className="text-primary hover:underline"
+					>
+						Return to Sign In
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen flex items-center justify-center">
+			<NiceLoader message="Completing sign in..." size="lg" />
+		</div>
+	);
+}
+
+/**
+ * Auth Callback Page
+ *
+ * Wrapped in Suspense as required by Next.js for useSearchParams
+ */
+export default function AuthCallbackPage() {
+	return (
+		<Suspense
+			fallback={
+				<div className="min-h-screen flex items-center justify-center">
+					<NiceLoader message="Loading..." size="lg" />
+				</div>
+			}
+		>
+			<AuthCallbackContent />
+		</Suspense>
+	);
+}

--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -17,7 +17,9 @@ export default function LoginPage() {
 		try {
 			await authClient.signIn.social({
 				provider: "github",
-				callbackURL: "/dashboard",
+				// Redirect to /auth/callback to let client-side verify OTT before
+				// accessing protected routes with server-side session checks
+				callbackURL: "/auth/callback",
 			});
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to sign in with GitHub");


### PR DESCRIPTION
## Summary
- Create `/auth/callback` page for client-side OTT verification
- Update OAuth callbackURL from `/dashboard` to `/auth/callback`
- Fixes cross-domain authentication flow where server-side checks blocked OTT verification

## Context
The crossDomain plugin uses one-time tokens (OTT) to establish sessions across domains (Convex on .convex.site, app on osschat.dev). The OAuth callback was redirecting to `/dashboard`, but the dashboard layout has server-side session checks that run before the client-side `crossDomainClient` plugin can verify the OTT.

## Test plan
- [ ] Login with GitHub OAuth on production
- [ ] Verify OTT is processed at /auth/callback
- [ ] Verify redirect to /dashboard after session is established

🤖 Generated with [Claude Code](https://claude.com/claude-code)