### PR TITLE
fix: simplify crossDomainClient config

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -11,12 +11,9 @@ export const authClient = createAuthClient({
 		convexClient(),
 		// Enable cross-domain authentication
 		// Required because Convex runs on .convex.site but app runs on osschat.dev
-		// This plugin handles session storage and one-time token verification
+		// This plugin verifies OTT and sets session cookies
 		crossDomainClient({
-			// Use localStorage for session persistence across page reloads
-			storage: typeof window !== "undefined" ? window.localStorage : undefined,
 			storagePrefix: "openchat",
-			disableCache: false,
 		}),
 	],
 });


### PR DESCRIPTION
## Summary
- Remove explicit localStorage storage from crossDomainClient configuration
- Let the plugin use its default behavior for session management

## Context
The explicit `storage: localStorage` configuration may have been preventing the crossDomain plugin from properly setting session cookies. The plugin should handle this automatically.

## Test plan
- [ ] Login with GitHub OAuth
- [ ] Verify session cookie is set after OTT verification
- [ ] Verify access to dashboard works

🤖 Generated with [Claude Code](https://claude.com/claude-code)