### PR TITLE
fix: restore crossDomain auth plugins for cross-origin cookie handling

### DIFF
--- a/apps/server/convex/auth.ts
+++ b/apps/server/convex/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { convex } from "@convex-dev/better-auth/plugins";
+import { convex, crossDomain } from "@convex-dev/better-auth/plugins";
 import { createClient, type GenericCtx } from "@convex-dev/better-auth";
 import { components } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
@@ -63,7 +63,15 @@ export const createAuth = (
 		database: authComponent.adapter(ctx),
 		secret: authSecret,
 		socialProviders,
-		plugins: [convex()],
+		plugins: [
+			convex(),
+			// Enable cross-domain authentication
+			// Required because Convex runs on .convex.site but app runs on osschat.dev
+			// This plugin adds OTT (one-time token) to OAuth callback for cross-domain session
+			crossDomain({
+				siteUrl: siteUrl,
+			}),
+		],
 		trustedOrigins: [
 			"http://localhost:3000",
 			"http://127.0.0.1:3000",

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
+import { NiceLoader } from "@/components/ui/nice-loader";
+
+/**
+ * Auth Callback Content Component
+ *
+ * Handles the one-time token (OTT) verification for cross-domain authentication.
+ * When OAuth completes, the user is redirected here with an OTT parameter.
+ * The crossDomainClient plugin automatically verifies the OTT and establishes the session cookie.
+ * Once authenticated, the user is redirected to their intended destination.
+ */
+function AuthCallbackContent() {
+	const searchParams = useSearchParams();
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const verifyAndRedirect = async () => {
+			try {
+				// The crossDomainClient plugin automatically processes OTT from URL
+				// and calls /api/auth/cross-domain/one-time-token/verify
+				// This sets the session cookie on osschat.dev domain
+
+				// Wait a moment for the OTT verification to complete
+				await new Promise((resolve) => setTimeout(resolve, 500));
+
+				// Check if session is now established
+				const session = await authClient.getSession();
+
+				if (session?.data?.user) {
+					// Session established, redirect to intended destination
+					const from = searchParams.get("from") || "/dashboard";
+					window.location.href = from;
+				} else {
+					// Wait a bit more and retry - OTT verification might still be in progress
+					await new Promise((resolve) => setTimeout(resolve, 1500));
+
+					const retrySession = await authClient.getSession();
+					if (retrySession?.data?.user) {
+						const from = searchParams.get("from") || "/dashboard";
+						window.location.href = from;
+					} else {
+						// Still no session, something went wrong
+						setError("Authentication failed. Please try signing in again.");
+					}
+				}
+			} catch (err) {
+				console.error("[Auth Callback] Error:", err);
+				setError("An error occurred during authentication.");
+			}
+		};
+
+		verifyAndRedirect();
+	}, [searchParams]);
+
+	if (error) {
+		return (
+			<div className="min-h-screen flex items-center justify-center">
+				<div className="text-center space-y-4">
+					<p className="text-red-500">{error}</p>
+					<button
+						onClick={() => (window.location.href = "/auth/sign-in")}
+						className="text-primary hover:underline"
+					>
+						Return to Sign In
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen flex items-center justify-center">
+			<NiceLoader message="Completing sign in..." size="lg" />
+		</div>
+	);
+}
+
+/**
+ * Auth Callback Page
+ *
+ * Wrapped in Suspense as required by Next.js for useSearchParams
+ */
+export default function AuthCallbackPage() {
+	return (
+		<Suspense
+			fallback={
+				<div className="min-h-screen flex items-center justify-center">
+					<NiceLoader message="Loading..." size="lg" />
+				</div>
+			}
+		>
+			<AuthCallbackContent />
+		</Suspense>
+	);
+}

--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -17,7 +17,9 @@ export default function LoginPage() {
 		try {
 			await authClient.signIn.social({
 				provider: "github",
-				callbackURL: "/dashboard",
+				// Redirect to /auth/callback to let client-side verify OTT
+				// before accessing protected routes with server-side session checks
+				callbackURL: "/auth/callback",
 			});
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to sign in with GitHub");

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/react";
-import { convexClient } from "@convex-dev/better-auth/client/plugins";
+import { convexClient, crossDomainClient } from "@convex-dev/better-auth/client/plugins";
 
 // Create auth client with Convex Better Auth
 // The convexClient plugin handles routing to /api/auth/[...all] which uses nextJsHandler()
@@ -7,5 +7,13 @@ import { convexClient } from "@convex-dev/better-auth/client/plugins";
 // Access env var directly to avoid build-time validation
 export const authClient = createAuthClient({
 	baseURL: process.env.NEXT_PUBLIC_APP_URL || "",
-	plugins: [convexClient()],
+	plugins: [
+		convexClient(),
+		// Enable cross-domain authentication
+		// Required because Convex runs on .convex.site but app runs on osschat.dev
+		// This plugin handles OTT (one-time token) verification to establish session cookies
+		crossDomainClient({
+			storagePrefix: "openchat",
+		}),
+	],
 });


### PR DESCRIPTION
## Summary

Restores the crossDomain and crossDomainClient plugins which ARE required for authentication to work across domains.

## Root Cause Analysis

The issue was that:
- Convex auth runs on `.convex.site` domain
- App runs on `osschat.dev` domain  
- Cookies cannot be directly set across these different domains
- The `crossDomain` plugin uses One-Time Tokens (OTT) to establish session cookies on the app domain

## Changes

- Re-add `crossDomain` plugin to `apps/server/convex/auth.ts`
- Re-add `crossDomainClient` plugin to `apps/web/src/lib/auth-client.ts`
- Re-create `/auth/callback` page for client-side OTT verification
- Update `callbackURL` to `/auth/callback` in sign-in page

## Auth Flow

1. User clicks "Continue with GitHub"
2. OAuth completes on Convex (`.convex.site`)
3. User redirected to `/auth/callback?ott=xxx`
4. `crossDomainClient` plugin verifies OTT via `/api/auth/cross-domain/one-time-token/verify`
5. Session cookie is set on `osschat.dev`
6. User redirected to dashboard with valid session

## Test plan

- [ ] Login with GitHub works
- [ ] Session cookie is set on osschat.dev
- [ ] Protected routes are accessible after login
- [ ] Session persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)