### PR TITLE
fix: enable standalone output for Docker builds

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -40,6 +40,8 @@ const nextConfig = {
 	// REMOVED: output: "standalone"
 	// Vercel has its own runtime and doesn't need standalone mode
 	// Keeping this enabled adds 150MB+ to builds and increases build time
+	// RE-ENABLED: output: "standalone" is REQUIRED for Docker/Railway builds
+	output: "standalone",
 	images: {
 		remotePatterns: [
 			{ protocol: "https", hostname: "ik.imagekit.io" },


### PR DESCRIPTION
Enabling `output: 'standalone'` in `next.config.mjs` because the `docker/web.Dockerfile` relies on the `.next/standalone` directory. Without this, the Docker build fails on Railway.