### PR TITLE
fix: verify OTT server-side to properly set browser cookies

### DIFF
--- a/apps/web/src/app/api/auth/callback-ott/route.ts
+++ b/apps/web/src/app/api/auth/callback-ott/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { splitCookiesString } from "set-cookie-parser";
+
+/**
+ * Server-side OTT verification handler
+ *
+ * This route verifies the One-Time Token (OTT) server-side and sets cookies
+ * BEFORE any client-side JavaScript runs. This is critical because:
+ *
+ * 1. crossDomainClient plugin uses credentials: "omit" which doesn't set browser cookies
+ * 2. Our middleware only checks browser cookies, not localStorage
+ * 3. By verifying server-side, we can set cookies during the redirect
+ *
+ * Flow:
+ * 1. Convex OAuth callback redirects to /auth/callback?ott=xxx
+ * 2. Callback page detects OTT and redirects to this route
+ * 3. This route verifies OTT and sets cookies
+ * 4. Redirects back to /auth/callback (without OTT) with cookies set
+ */
+export async function GET(request: NextRequest) {
+	const searchParams = request.nextUrl.searchParams;
+	const ott = searchParams.get("ott");
+	const from = searchParams.get("from");
+
+	if (!ott) {
+		// No OTT provided, redirect to sign-in
+		return NextResponse.redirect(new URL("/auth/sign-in", request.url));
+	}
+
+	try {
+		// Verify OTT by calling our own API route (which proxies to Convex)
+		const verifyUrl = new URL(
+			"/api/auth/cross-domain/one-time-token/verify",
+			request.url
+		);
+
+		const verifyResponse = await fetch(verifyUrl.toString(), {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ token: ott }),
+		});
+
+		// Build redirect URL
+		const callbackUrl = new URL("/auth/callback", request.url);
+		if (from) {
+			callbackUrl.searchParams.set("from", from);
+		}
+		// Mark as verified so the callback page knows cookies should be set
+		callbackUrl.searchParams.set("verified", "true");
+
+		// Create redirect response
+		const redirectResponse = NextResponse.redirect(callbackUrl);
+
+		if (verifyResponse.ok) {
+			// Extract Set-Cookie and Set-Better-Auth-Cookie headers from verify response
+			// and add them to our redirect response
+
+			// Handle Set-Better-Auth-Cookie header (from Convex crossDomain plugin)
+			const betterAuthCookie = verifyResponse.headers.get(
+				"Set-Better-Auth-Cookie"
+			);
+			if (betterAuthCookie) {
+				const cookies = splitCookiesString(betterAuthCookie);
+				for (const cookie of cookies) {
+					// Strip Domain attribute - if it's .convex.site, it's invalid for our domain
+					let sanitizedCookie = cookie.replace(/;\s*[Dd]omain=[^;]+/, "");
+
+					// In development, strip Secure attribute so cookies work on HTTP localhost
+					if (process.env.NODE_ENV !== "production") {
+						sanitizedCookie = sanitizedCookie.replace(/;\s*[Ss]ecure/g, "");
+						sanitizedCookie = sanitizedCookie.replace(/^__Secure-/i, "");
+					}
+
+					redirectResponse.headers.append("Set-Cookie", sanitizedCookie);
+				}
+			}
+
+			// Also handle any Set-Cookie headers directly
+			const setCookieHeader = verifyResponse.headers.get("Set-Cookie");
+			if (setCookieHeader) {
+				const cookies = splitCookiesString(setCookieHeader);
+				for (const cookie of cookies) {
+					// Strip Domain attribute
+					let sanitizedCookie = cookie.replace(/;\s*[Dd]omain=[^;]+/, "");
+
+					if (process.env.NODE_ENV !== "production") {
+						sanitizedCookie = sanitizedCookie.replace(/;\s*[Ss]ecure/g, "");
+						sanitizedCookie = sanitizedCookie.replace(/^__Secure-/i, "");
+					}
+
+					redirectResponse.headers.append("Set-Cookie", sanitizedCookie);
+				}
+			}
+		}
+
+		return redirectResponse;
+	} catch (error) {
+		console.error("[OTT Callback] Error verifying OTT:", error);
+
+		// On error, redirect to callback page anyway - it will handle the error state
+		const callbackUrl = new URL("/auth/callback", request.url);
+		if (from) {
+			callbackUrl.searchParams.set("from", from);
+		}
+		callbackUrl.searchParams.set("error", "verification_failed");
+
+		return NextResponse.redirect(callbackUrl);
+	}
+}

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState, useRef } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { NiceLoader } from "@/components/ui/nice-loader";
@@ -10,117 +10,76 @@ import { NiceLoader } from "@/components/ui/nice-loader";
  *
  * Handles the OAuth callback for cross-domain authentication.
  *
- * IMPORTANT: We MUST manually verify the OTT with `credentials: "include"` BEFORE
- * the crossDomainClient does (which uses credentials: "omit"). This ensures the
- * Set-Cookie headers from our route handler are actually stored by the browser.
- * Without this, cookies only go to localStorage and middleware can't see them.
+ * NOTE: The middleware intercepts requests to /auth/callback with an OTT parameter
+ * and redirects to /api/auth/callback-ott for server-side verification.
+ * By the time this page loads, OTT verification is complete and cookies are set.
+ * This page only needs to poll for the session and redirect to the dashboard.
  */
 function AuthCallbackContent() {
 	const searchParams = useSearchParams();
 	const [error, setError] = useState<string | null>(null);
 	const [checking, setChecking] = useState(true);
-	const verifyingRef = useRef(false);
 
 	// Extract params once to avoid dependency issues
-	const ott = searchParams.get("ott");
 	const from = searchParams.get("from");
+	const errorParam = searchParams.get("error");
 
 	useEffect(() => {
 		let cancelled = false;
 
-		const verifyOTTAndCheckSession = async () => {
-			// Prevent double verification
-			if (verifyingRef.current) return;
-			verifyingRef.current = true;
+		// Handle error from server-side verification
+		if (errorParam === "verification_failed") {
+			setError("Authentication failed. Please try signing in again.");
+			setChecking(false);
+			return;
+		}
 
-			try {
+		const checkSession = async () => {
+			if (cancelled) return;
 
-				if (ott) {
-					console.log("[Auth Callback] Found OTT, verifying with credentials: include...");
+			let attempts = 0;
+			const maxAttempts = 15; // Increased for more patience
 
-					// CRITICAL: Verify OTT with credentials: "include" to actually store cookies!
-					// crossDomainClient uses credentials: "omit" which prevents cookie storage.
-					// By doing this FIRST, we ensure Set-Cookie headers from our route handler
-					// are stored by the browser as actual cookies (not just localStorage).
-					const baseUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
-					if (!process.env.NEXT_PUBLIC_APP_URL) {
-						console.warn("[Auth Callback] NEXT_PUBLIC_APP_URL not set, falling back to window.location.origin");
+			const poll = async () => {
+				if (cancelled) return;
+
+				try {
+					const session = await authClient.getSession();
+
+					if (session?.data?.user) {
+						console.log("[Auth Callback] Session established, redirecting...");
+						window.location.href = from || "/dashboard";
+						return;
 					}
-					const verifyResponse = await fetch(`${baseUrl}/api/auth/cross-domain/one-time-token/verify`, {
-						method: "POST",
-						headers: {
-							"Content-Type": "application/json",
-						},
-						body: JSON.stringify({ token: ott }),
-						credentials: "include", // THIS IS THE KEY - stores Set-Cookie headers!
-					});
 
-					if (!verifyResponse.ok) {
-						const errorData = await verifyResponse.json().catch(() => ({}));
-						console.error("[Auth Callback] OTT verification failed:", verifyResponse.status, errorData);
-						// Don't show error yet - might be already used, check session below
+					attempts++;
+					if (attempts < maxAttempts) {
+						console.log(`[Auth Callback] Waiting for session... (attempt ${attempts}/${maxAttempts})`);
+						setTimeout(poll, 500);
 					} else {
-						console.log("[Auth Callback] OTT verified successfully, cookies should be set");
+						console.error("[Auth Callback] Session not established after waiting");
+						setError("Authentication is taking longer than expected. Please try signing in again.");
+						setChecking(false);
 					}
-
-					// Clean up URL to remove OTT
-					const newUrl = new URL(window.location.href);
-					newUrl.searchParams.delete("ott");
-					window.history.replaceState({}, "", newUrl.toString());
-				}
-
-				// Now poll for session
-				let attempts = 0;
-				const maxAttempts = 10;
-
-				const checkSession = async () => {
-					if (cancelled) return;
-
-					try {
-						const session = await authClient.getSession();
-
-						if (session?.data?.user) {
-							console.log("[Auth Callback] Session established, redirecting...");
-							window.location.href = from || "/dashboard";
-							return;
-						}
-
-						attempts++;
-						if (attempts < maxAttempts) {
-							console.log(`[Auth Callback] Waiting for session... (attempt ${attempts}/${maxAttempts})`);
-							setTimeout(checkSession, 500);
-						} else {
-							console.error("[Auth Callback] Session not established after waiting");
-							setError("Authentication is taking longer than expected. Please try signing in again.");
-							setChecking(false);
-						}
-					} catch (err) {
-						console.error("[Auth Callback] Error checking session:", err);
-						if (!cancelled) {
-							setError("An error occurred during authentication.");
-							setChecking(false);
-						}
+				} catch (err) {
+					console.error("[Auth Callback] Error checking session:", err);
+					if (!cancelled) {
+						setError("An error occurred during authentication.");
+						setChecking(false);
 					}
-				};
-
-				// Start checking session
-				await checkSession();
-			} catch (err) {
-				console.error("[Auth Callback] Error in auth flow:", err);
-				if (!cancelled) {
-					setError("An error occurred during authentication.");
-					setChecking(false);
 				}
-			}
+			};
+
+			await poll();
 		};
 
-		// Start immediately
-		verifyOTTAndCheckSession();
+		// Start checking session - by this point OTT should be verified and cookies set
+		checkSession();
 
 		return () => {
 			cancelled = true;
 		};
-	}, [ott, from]);
+	}, [from, errorParam]);
 
 	if (error) {
 		return (


### PR DESCRIPTION
## Summary

- Fix production auth where browser cookies were never set, only localStorage
- The crossDomainClient plugin was consuming the single-use OTT with `credentials: "omit"` before our client-side code could run
- Solution: Intercept OTT verification in middleware and handle server-side

## Root Cause

1. OAuth completes → Convex redirects to `/auth/callback?ott=xxx`
2. Page loads → crossDomainClient plugin immediately verifies OTT with `credentials: "omit"`
3. This stores session in localStorage but NOT in browser cookies (credentials: omit prevents cookie storage)
4. Our client-side verification tried to verify the same OTT → already consumed → fails
5. Browser cookies are never set → middleware redirects to sign-in

## Solution

1. **Middleware** (`middleware.ts`): Intercept requests to `/auth/callback` with OTT parameter and redirect to server-side handler
2. **New API Route** (`/api/auth/callback-ott/route.ts`): Verify OTT server-side and set cookies in the redirect response
3. **Callback Page** (`page.tsx`): Simplified to just poll for session (OTT already verified by the time it loads)

This ensures cookies are set during the redirect, BEFORE any client-side JavaScript runs.

## Test plan

- [ ] Deploy to production
- [ ] Test GitHub OAuth sign-in flow
- [ ] Verify browser cookies are set (check Application > Cookies in DevTools)
- [ ] Verify protected routes work without redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)