### PR TITLE
fix: add credentials include to auth client for production cookie handling

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -15,4 +15,7 @@ import { convexClient } from "@convex-dev/better-auth/client/plugins";
 export const authClient = createAuthClient({
 	baseURL: process.env.NEXT_PUBLIC_APP_URL || "",
 	plugins: [convexClient()],
+	fetchOptions: {
+		credentials: "include",
+	},
 });


### PR DESCRIPTION
## Summary
- Added `fetchOptions: { credentials: "include" }` to the auth client configuration
- Fixes production authentication issue where users were redirected back to sign-in after OAuth callback

## Problem
The auth client was missing `credentials: "include"` in fetchOptions, which caused browsers to not send session cookies with auth requests in production. After OAuth flow completed and cookies were set, subsequent calls to `authClient.getSession()` in the callback page didn't include the session cookie, causing session verification to fail.

## Root Cause Analysis
- OAuth flow completes successfully, cookie is set via `Set-Cookie` header
- User redirects to `/auth/callback` which polls `authClient.getSession()`
- Without `credentials: "include"`, browser doesn't send cookies with fetch requests
- Session verification fails → redirect back to sign-in

## Solution
Added `fetchOptions: { credentials: "include" }` to ensure cookies are always sent with auth client requests.

## Test plan
- [x] TypeScript check passes
- [x] Lint passes (only pre-existing warnings)
- [ ] Test OAuth flow in production after deploy
- [ ] Verify session persists after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)