### PR TITLE
fix: use request host header for internal auth calls

### DIFF
--- a/apps/web/src/lib/auth-server.ts
+++ b/apps/web/src/lib/auth-server.ts
@@ -177,11 +177,19 @@ export async function getUserContextFromRequest(request: Request): Promise<UserC
 	}
 
 	// Call better-auth API to get session
+	// Use the request's origin for the base URL to ensure internal routing works
 	try {
-		const baseUrl =
-			process.env.NEXT_PUBLIC_APP_URL ||
-			process.env.SITE_URL ||
-			"http://localhost:3000";
+		// Try to get the host from the request for internal calls
+		const host = request.headers.get("host");
+		const protocol = request.headers.get("x-forwarded-proto") || "https";
+		const baseUrl = host
+			? `${protocol}://${host}`
+			: process.env.NEXT_PUBLIC_APP_URL ||
+			  process.env.SITE_URL ||
+			  "http://localhost:3000";
+
+		console.log("[Auth Server API] Fetching session from:", `${baseUrl}/api/auth/get-session`);
+
 		const response = await fetch(`${baseUrl}/api/auth/get-session`, {
 			headers: {
 				Cookie: cookieHeader,


### PR DESCRIPTION
## Summary
Use the request's host header to construct the base URL for internal auth calls, ensuring proper routing in serverless environments like Vercel.

## Problem
API routes making internal HTTP calls to `/api/auth/get-session` were failing because `NEXT_PUBLIC_APP_URL` might not resolve correctly for internal server-to-server calls.

## Solution
Extract the host and protocol from the incoming request headers to construct the base URL, which ensures the internal call routes correctly.

## Test plan
- [ ] Create a new chat
- [ ] Send a message
- [ ] Load existing chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)