### PR TITLE
fix: convert chat page to client-side data loading for Edge compatibility

### DIFF
--- a/apps/web/src/app/dashboard/chat/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/chat/[id]/page.tsx
@@ -1,51 +1,24 @@
-import type { Id } from "@server/convex/_generated/dataModel";
 import ChatRoomClient from "@/components/chat-room-wrapper";
-import { listMessagesForChat } from "@/lib/convex-server";
-import { redirect } from "next/navigation";
-import { logError } from "@/lib/logger-server";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Chat Page - Now uses client-side data loading
+ *
+ * Previously, this page used server-side auth and data fetching which failed
+ * in Edge environments (Vercel, Cloudflare) because cookies() from next/headers
+ * doesn't work reliably.
+ *
+ * Now, the page just renders the ChatRoomClient which:
+ * - Handles authentication client-side via AuthGuard in the layout
+ * - Fetches messages via the client-side API
+ */
 export default async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
-	try {
-		const { id: chatIdParam } = await params;
+	const { id: chatIdParam } = await params;
 
-		// Validate chat ID format
-		if (!chatIdParam || typeof chatIdParam !== "string") {
-			logError("Invalid chat ID format", { chatIdParam });
-			redirect("/dashboard");
-		}
-
-		// PERFORMANCE FIX: Use combined helper to eliminate redundant getUserContext call
-		const { getConvexUserFromSession } = await import("@/lib/convex-server");
-		const [, convexUserId] = await getConvexUserFromSession();
-		const messages = await listMessagesForChat(convexUserId, chatIdParam as Id<"chats">);
-
-		// PERFORMANCE FIX: Cache Date objects to avoid redundant serialization
-		// Instead of creating new Date() for each message, serialize once
-		const initialMessages = messages.map((message) => {
-			// Direct conversion from timestamp to ISO string without intermediate Date object
-			const isoString = new Date(message.createdAt).toISOString();
-			return {
-				id: message._id,
-				role: message.role,
-				content: message.content,
-				reasoning: message.reasoning,
-				createdAt: isoString,
-				attachments: message.attachments,
-			};
-		});
-
-		return (
-			<div className="mx-auto flex h-full w-full max-w-5xl flex-1 flex-col gap-0 min-h-0">
-				<ChatRoomClient chatId={chatIdParam} initialMessages={initialMessages} />
-			</div>
-		);
-	} catch (error) {
-		// Log the error with context for debugging
-		logError("Error loading chat page", error);
-
-		// Redirect to dashboard on any error (auth, database, network, etc.)
-		redirect("/dashboard");
-	}
+	return (
+		<div className="mx-auto flex h-full w-full max-w-5xl flex-1 flex-col gap-0 min-h-0">
+			<ChatRoomClient chatId={chatIdParam} initialMessages={[]} />
+		</div>
+	);
 }

--- a/apps/web/src/components/chat-room-wrapper.tsx
+++ b/apps/web/src/components/chat-room-wrapper.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { Provider as ChatStoreProvider } from "@ai-sdk-tools/store";
 import dynamic from "next/dynamic";
 import { normalizeMessage, toUiMessage } from "@/lib/chat-message-utils";
 import { ChatLoader } from "@/components/ui/nice-loader";
 import { ChatErrorBoundary } from "@/components/chat-error-boundary";
+import { logError } from "@/lib/logger";
 
 // Lazy load the heavy ChatRoom component (600+ lines)
 const ChatRoom = dynamic(() => import("@/components/chat-room"), {
@@ -13,22 +14,72 @@ const ChatRoom = dynamic(() => import("@/components/chat-room"), {
   loading: () => <ChatLoader />,
 });
 
+type MessageData = {
+  id: string;
+  role: string;
+  content: string;
+  reasoning?: string;
+  createdAt: string | Date;
+  attachments?: Array<{
+    storageId: string;
+    filename: string;
+    contentType: string;
+    size: number;
+    uploadedAt: number;
+  }>;
+};
+
 type ChatRoomProps = {
   chatId: string;
-  initialMessages: Array<{
-    id: string;
-    role: string;
-    content: string;
-    reasoning?: string;
-    createdAt: string | Date;
-  }>;
+  initialMessages: MessageData[];
 };
 
 export default function ChatRoomWrapper(props: ChatRoomProps) {
   const [mounted, setMounted] = useState(false);
+  const [messages, setMessages] = useState<MessageData[]>(props.initialMessages);
+  const [isLoading, setIsLoading] = useState(props.initialMessages.length === 0);
+  const hasFetchedRef = useRef(false);
+
+  // CLIENT-SIDE MESSAGE FETCHING: Load messages from API when initialMessages is empty
+  // This handles the case where server-side fetching isn't available (e.g., Edge environments)
+  useEffect(() => {
+    if (hasFetchedRef.current) return;
+    if (props.initialMessages.length > 0) return;
+
+    const fetchMessages = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch(`/api/chats/${props.chatId}/prefetch`, {
+          method: "GET",
+          credentials: "include",
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (data.ok && data.messages && Array.isArray(data.messages)) {
+            setMessages(data.messages.map((m: { id: string; role: string; content: string; reasoning?: string; createdAt: string; attachments?: MessageData["attachments"] }) => ({
+              id: m.id,
+              role: m.role,
+              content: m.content,
+              reasoning: m.reasoning,
+              createdAt: m.createdAt,
+              attachments: m.attachments,
+            })));
+            hasFetchedRef.current = true;
+          }
+        }
+      } catch (error) {
+        logError("Failed to fetch chat messages", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchMessages();
+  }, [props.chatId, props.initialMessages.length]);
+
   const initialUiMessages = useMemo(
     () =>
-      props.initialMessages.map((message) =>
+      messages.map((message) =>
         toUiMessage(
           normalizeMessage({
             id: message.id,
@@ -39,14 +90,14 @@ export default function ChatRoomWrapper(props: ChatRoomProps) {
           }),
         ),
       ),
-    [props.initialMessages],
+    [messages],
   );
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  if (!mounted) return <ChatLoader />;
+  if (!mounted || isLoading) return <ChatLoader />;
   return (
     <div className="animate-fade-in">
       <ChatErrorBoundary chatId={props.chatId}>


### PR DESCRIPTION
## Summary
- Converted chat page from server-side to client-side data loading
- This fixes navigation to chat pages which was redirecting to `/dashboard` due to failed server-side auth

## Root Cause
The chat page used `getConvexUserFromSession()` → `getUserContext()` which relies on `cookies()` from next/headers. This doesn't work in Edge environments (Vercel, Cloudflare), causing the page to throw an error and redirect back to `/dashboard`.

## Changes
- `apps/web/src/app/dashboard/chat/[id]/page.tsx`: Simplified to just render ChatRoomClient with empty messages
- `apps/web/src/components/chat-room-wrapper.tsx`: Added client-side message fetching via `/api/chats/[id]/prefetch`

## Test plan
- [ ] Navigate to an existing chat - should load the chat and its messages
- [ ] Create a new chat - should navigate to it and show empty chat room
- [ ] Click on chats in sidebar - should navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)