### PR TITLE
fix: prevent sidebar chat list from resetting on navigation

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -163,7 +163,11 @@ function AppSidebar({ initialChats = [], ...sidebarProps }: AppSidebarProps) {
   const [chats, setChats] = useState<ChatListItem[]>(() => dedupedInitialChats);
 
   useEffect(() => {
-    setChats(dedupedInitialChats);
+    // Only sync from props if initialChats has actual data
+    // When empty, we rely on client-side fetching and don't want to overwrite
+    if (dedupedInitialChats.length > 0) {
+      setChats(dedupedInitialChats);
+    }
   }, [dedupedInitialChats]);
 
   // CLIENT-SIDE CHAT FETCHING: Load chats from API when initialChats is empty


### PR DESCRIPTION
## Summary
- Fixes chat list disappearing when navigating between pages (e.g., dashboard → prompt library)
- The `useEffect` that syncs `initialChats` to state was overwriting client-fetched chats because `initialChats=[]` creates a new array reference each render

## Root Cause
When navigating between pages under `/dashboard/*`, the layout re-renders with `initialChats=[]`. This new array reference triggers:
1. `useMemo` to recompute `dedupedInitialChats` (returning a new empty array)
2. `useEffect` to run and set `chats` to empty, overwriting the previously client-fetched chats

## Fix
Only sync from props when there are actual chats to sync. When `initialChats` is empty, we rely on client-side fetching and don't overwrite the existing state.

## Test plan
- [ ] Load dashboard - verify chats appear
- [ ] Navigate to Prompt Library - verify chats remain visible
- [ ] Navigate back to dashboard - verify chats still visible
- [ ] Create new chat - verify it appears in sidebar
- [ ] Refresh page - verify chats reload correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)