### PR TITLE
feat: improve mobile chat UI and add chat preloading

### DIFF
--- a/apps/web/src/components/ai-elements/actions.tsx
+++ b/apps/web/src/components/ai-elements/actions.tsx
@@ -8,9 +8,9 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { ComponentProps } from "react";
+import type { HTMLAttributes, ComponentProps } from "react";
 
-export type ActionsProps = ComponentProps<"div">;
+export type ActionsProps = HTMLAttributes<HTMLDivElement>;
 
 export const Actions = ({ className, children, ...props }: ActionsProps) => (
   <div className={cn("flex items-center gap-1", className)} {...props}>

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon } from "@/lib/icons";
-import type { ComponentProps } from "react";
+import type { ComponentProps, HTMLAttributes } from "react";
 import { useCallback } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { borderRadius, iconSize, spacing } from "@/styles/design-tokens";
@@ -31,7 +31,7 @@ export const ConversationContent = ({
   <StickToBottom.Content className={cn(spacing.padding.lg, className)} {...props} />
 );
 
-export type ConversationEmptyStateProps = ComponentProps<"div"> & {
+export type ConversationEmptyStateProps = HTMLAttributes<HTMLDivElement> & {
   title?: string;
   description?: string;
   icon?: React.ReactNode;

--- a/apps/web/src/components/ai-elements/model-selector.tsx
+++ b/apps/web/src/components/ai-elements/model-selector.tsx
@@ -16,7 +16,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import type { ReactNode, ComponentProps } from "react";
+import type { ReactNode, ComponentProps, ImgHTMLAttributes, HTMLAttributes } from "react";
 
 export type ModelSelectorProps = ComponentProps<typeof Dialog>;
 
@@ -109,7 +109,7 @@ export const ModelSelectorSeparator = (props: ModelSelectorSeparatorProps) => (
 );
 
 export type ModelSelectorLogoProps = Omit<
-  ComponentProps<"img">,
+  ImgHTMLAttributes<HTMLImageElement>,
   "src" | "alt"
 > & {
   provider:
@@ -191,7 +191,7 @@ export const ModelSelectorLogo = ({
   />
 );
 
-export type ModelSelectorLogoGroupProps = ComponentProps<"div">;
+export type ModelSelectorLogoGroupProps = HTMLAttributes<HTMLDivElement>;
 
 export const ModelSelectorLogoGroup = ({
   className,
@@ -206,7 +206,7 @@ export const ModelSelectorLogoGroup = ({
   />
 );
 
-export type ModelSelectorNameProps = ComponentProps<"span">;
+export type ModelSelectorNameProps = HTMLAttributes<HTMLSpanElement>;
 
 export const ModelSelectorName = ({
   className,

--- a/apps/web/src/components/chat-composer.tsx
+++ b/apps/web/src/components/chat-composer.tsx
@@ -759,12 +759,13 @@ function ChatComposer({
 
       <div
         className={cn(
-          "border-border flex flex-col border-t sm:flex-row sm:items-center sm:justify-between",
-          spacing.gap.lg,
+          "border-border flex items-center justify-between border-t",
+          spacing.gap.sm,
           spacing.padding.lg,
         )}
       >
-        <div className={cn("flex items-center flex-wrap", spacing.gap.sm)}>
+        {/* Controls row - single row, compact on mobile */}
+        <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0 overflow-x-auto">
           <ModelSelector
             options={modelOptions}
             value={
@@ -810,13 +811,16 @@ function ChatComposer({
               disabled={disabled || isBusy}
             />
           )}
-          <ContextUsageIndicator
-            currentTokens={currentTokenCount}
-            maxTokens={maxContextTokens}
-          />
+          <div className="hidden sm:block">
+            <ContextUsageIndicator
+              currentTokens={currentTokenCount}
+              maxTokens={maxContextTokens}
+            />
+          </div>
         </div>
 
-        <div className={cn("flex flex-col items-end", spacing.gap.xs)}>
+        {/* Send button - icon only on mobile, with text on desktop */}
+        <div className="flex flex-col items-end gap-1 shrink-0">
           {errorMessage && (
             <span
               id="composer-error"
@@ -850,11 +854,11 @@ function ChatComposer({
             }
             aria-busy={isSending}
             className={cn(
-              "flex h-9 items-center text-sm font-medium transition-all duration-100 ease-out hover:scale-[1.01] active:scale-[0.95]",
+              "flex items-center justify-center text-sm font-medium transition-all duration-100 ease-out hover:scale-[1.01] active:scale-[0.95]",
               borderRadius.lg,
-              spacing.gap.sm,
               shadows.sm,
-              "px-4",
+              // Icon only on mobile (square), text + icon on desktop
+              "size-10 sm:h-10 sm:w-auto sm:px-4 sm:gap-2",
               // INSTANT: Show Stop style immediately when sending OR streaming
               (isSending || isStreaming)
                 ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
@@ -869,7 +873,7 @@ function ChatComposer({
             ) : (
               <SendIcon className="size-4 transition-transform duration-100 ease-out" aria-hidden="true" />
             )}
-            <span>{(isSending || isStreaming) ? "Stop" : "Send"}</span>
+            <span className="hidden sm:inline">{(isSending || isStreaming) ? "Stop" : "Send"}</span>
           </button>
         </div>
       </div>

--- a/apps/web/src/components/help-button.tsx
+++ b/apps/web/src/components/help-button.tsx
@@ -10,7 +10,7 @@ export function HelpButton() {
       href="https://github.com/opentech1/openchat/issues/new"
       target="_blank"
       rel="noopener noreferrer"
-      className="fixed bottom-6 right-6 z-50"
+      className="fixed bottom-6 right-6 z-50 hidden md:block"
     >
       <Button
         size="icon"

--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -434,7 +434,7 @@ function ModelSelector({ options, value, onChange, disabled, loading, open: cont
 					variant="outline"
 					onClick={initiateLogin}
 					disabled={isOAuthLoading}
-					className="w-[200px] justify-start gap-2"
+					className="w-auto min-w-0 max-w-[200px] justify-start gap-2"
 				>
 					{isOAuthLoading ? (
 						<Loader2 className="size-4 animate-spin" />
@@ -458,7 +458,7 @@ function ModelSelector({ options, value, onChange, disabled, loading, open: cont
 				<Button
 					variant="outline"
 					disabled={disabled || loading || options.length === 0}
-					className="w-[200px] justify-between gap-2"
+					className="w-auto min-w-0 max-w-[140px] sm:max-w-[200px] justify-between gap-2"
 				>
 					<div className="flex items-center gap-2 flex-1 min-w-0">
 						{selectedProvider && (

--- a/apps/web/src/components/reasoning-controls.tsx
+++ b/apps/web/src/components/reasoning-controls.tsx
@@ -189,14 +189,16 @@ export function ReasoningControls({
 					type="button"
 					disabled={disabled}
 					className={cn(
-						"inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium",
+						"inline-flex items-center gap-1.5 rounded-md border border-border bg-background text-sm font-medium",
+						// Compact on mobile (icon-only), larger on desktop
+						"size-9 justify-center sm:size-auto sm:px-3 sm:py-1.5 sm:justify-start",
 						"hover:bg-accent hover:text-accent-foreground",
 						"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
 						"disabled:cursor-not-allowed disabled:opacity-50",
 						"transition-colors",
 						currentOption !== "off" && "border-purple-500/50 bg-purple-500/5"
 					)}
-					aria-label="Select reasoning level"
+					aria-label={`Reasoning: ${currentLabel}`}
 				>
 					<Brain
 						className={cn(
@@ -204,9 +206,9 @@ export function ReasoningControls({
 							currentOption !== "off" ? "text-purple-500" : "text-muted-foreground"
 						)}
 					/>
-					<span>{currentLabel}</span>
+					<span className="hidden sm:inline">{currentLabel}</span>
 					<svg
-						className="size-4 text-muted-foreground ml-1"
+						className="hidden sm:block size-4 text-muted-foreground"
 						fill="none"
 						stroke="currentColor"
 						viewBox="0 0 24 24"
@@ -220,6 +222,7 @@ export function ReasoningControls({
 				<Popover.Content
 					align="start"
 					sideOffset={4}
+					collisionPadding={16}
 					className={cn(
 						"z-50 min-w-[200px] overflow-hidden rounded-md border border-border bg-popover p-1 shadow-md",
 						"data-[state=open]:animate-in data-[state=closed]:animate-out",


### PR DESCRIPTION
## Summary
- Make Model Selector responsive (140px on mobile, 200px on desktop)
- Make Reasoning Controls icon-only on mobile (36px square button)
- Add collision padding to reasoning popover to prevent edge overflow on mobile
- Implement compact single-row layout for chat composer toolbar
- Hide help button on mobile to save screen space
- Unify dashboard and chat inputs (dashboard now uses ChatComposer directly)
- Add proactive prefetching for top 5 chats when sidebar loads (helps mobile where no hover)
- Fix React type errors in ai-elements components (use HTMLAttributes instead of ComponentProps)

## Test plan
- [ ] Test mobile chat input layout (398px viewport)
- [ ] Verify Model Selector is narrower on mobile
- [ ] Verify Reasoning Controls shows icon only on mobile
- [ ] Verify reasoning popover doesn't go off-screen on mobile
- [ ] Verify dashboard input has all features (reasoning, file upload when in chat)
- [ ] Verify chat preloading works (top 5 chats should load faster)
- [ ] Verify help button is hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)