### PR TITLE
fix: stabilize virtualizer ref for React 19 and allow Cloudflare Insights

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -8,7 +8,7 @@ import { type NextRequest, NextResponse } from "next/server";
  */
 const BASE_CSP_DIRECTIVES = [
 	"default-src 'self'",
-	"script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.convex.cloud https://*.convex.site https://us.i.posthog.com https://us-assets.i.posthog.com https://unpkg.com https://va.vercel-scripts.com",
+	"script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.convex.cloud https://*.convex.site https://us.i.posthog.com https://us-assets.i.posthog.com https://unpkg.com https://va.vercel-scripts.com https://static.cloudflareinsights.com",
 	"connect-src 'self' https://*.convex.cloud https://*.convex.site wss://*.convex.cloud wss://*.convex.site https://openrouter.ai https://us.i.posthog.com https://us-assets.i.posthog.com",
 	"img-src 'self' blob: data: https://*.convex.cloud https://*.convex.site https://avatar.vercel.sh https://avatars.githubusercontent.com https://models.dev",
 	"font-src 'self' data:",


### PR DESCRIPTION
## Summary
- Create stable `measureElementRef` callback to prevent infinite re-renders from `virtualizer.measureElement`
- Disable virtualization until after mount to prevent hydration mismatch
- Add `https://static.cloudflareinsights.com` to CSP script-src

## Problem
After Next.js 16 migration, React errors #418 (hydration mismatch) and #185 (max update depth exceeded) still occur on page reload. The root cause was the virtualizer's `measureElement` callback creating new function references on every render, which:
1. Triggers element measurements → state updates → re-render → infinite loop
2. Causes hydration mismatches when measurements run before hydration completes

## Solution
1. **Stable ref callback**: Wrap `virtualizer.measureElement` in `useCallback` with `isMounted` guard
2. **Deferred virtualization**: Only enable virtualization after component mounts (`isMounted && messages.length > 20`)
3. **CSP fix**: Allow Cloudflare Insights beacon script

## Test plan
- [ ] Reload chat page with messages - no React errors in console
- [ ] Scroll through long chat with 20+ messages - virtualization works correctly
- [ ] Verify Cloudflare Insights loads without CSP errors
- [ ] Stream a new response and reload mid-stream - handles reconnection gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)