### PR TITLE
fix: completely disable virtualization to fix React errors #418/#185

### DIFF
--- a/apps/web/src/components/chat-messages-panel.tsx
+++ b/apps/web/src/components/chat-messages-panel.tsx
@@ -123,9 +123,13 @@ function ChatMessagesPanelComponent({
     return `${last.id}:${last.role}:${last.content.length}`;
   }, [hasMessages, messages]);
 
-  // Virtualization setup - only virtualize when we have many messages (>20)
-  // CRITICAL: Disable virtualization during initial render to prevent hydration mismatch
-  const shouldVirtualize = isMounted && messages.length > 20;
+  // EMERGENCY FIX: Completely disable virtualization to fix React errors #418/#185
+  // The @tanstack/react-virtual library causes infinite re-render loops during hydration
+  // even with the virtualizerRef workaround. The error occurs INSIDE the library code.
+  // TODO: Re-implement SSR-safe virtualization when @tanstack/react-virtual fixes React 19 support
+  // See: https://github.com/TanStack/virtual/issues/743
+  // See: https://github.com/TanStack/virtual/issues/924
+  const shouldVirtualize = false;
   const virtualizer = useVirtualizer({
     count: messages.length,
     getScrollElement: () => viewportRef.current,


### PR DESCRIPTION
## Summary
- **EMERGENCY FIX**: Completely disable @tanstack/react-virtual virtualization
- PR #434's `virtualizerRef` workaround was insufficient - errors still occur
- The error happens INSIDE the library code during React 19 hydration, not in our wrapper
- This sets `shouldVirtualize = false` to force all messages to use the non-virtualized render path

## Root Cause Analysis
The `@tanstack/react-virtual` library has known compatibility issues with React 19:
- [Issue #743](https://github.com/TanStack/virtual/issues/743): React 19 optimizes away virtualizer calls
- [Issue #924](https://github.com/TanStack/virtual/issues/924): Maximum update depth exceeded

The previous fixes (PRs #431, #432, #433, #434) attempted workarounds but the error persists because it originates INSIDE the library's internal code, not in our component wrapper.

## Trade-off
- **Downside**: No virtualization means all messages render at once (potential performance impact for very long chats)
- **Upside**: Fixes the React errors #418/#185 that break the app on page reload

## Test plan
- [ ] Reload page during streaming - no React errors should appear
- [ ] Chat with 50+ messages loads correctly
- [ ] Scrolling works smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)