### PR TITLE
fix: resolve hydration mismatch in AuthGuard and dashboard layout

### DIFF
--- a/apps/web/src/components/auth-guard.tsx
+++ b/apps/web/src/components/auth-guard.tsx
@@ -1,34 +1,40 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 
 /**
  * Client-side authentication guard
  *
- * Uses the better-auth useSession hook for optimized session checking with caching.
- * Shows content immediately while auth check happens in background.
- * Only redirects to sign-in if definitively not authenticated.
+ * HYDRATION FIX: Always render children on first render to prevent hydration mismatch.
+ * The useSession hook can return different values on server vs client:
+ * - Server: { isPending: false, data: null } (no session available)
+ * - Client: { isPending: true, data: null } (loading from localStorage)
+ *
+ * This caused hydration errors because server rendered null while client rendered children.
+ * Now we always render children and only redirect via useEffect after confirming no session.
  */
 export function AuthGuard({ children }: { children: ReactNode }) {
 	const router = useRouter();
 	const { data: session, isPending } = authClient.useSession();
+	const [shouldRedirect, setShouldRedirect] = useState(false);
 
 	useEffect(() => {
 		// Only redirect when we're certain there's no session
 		// isPending = true means we're still checking
 		// session = null AND isPending = false means definitely not authenticated
 		if (!isPending && !session?.user) {
+			setShouldRedirect(true);
 			router.replace("/auth/sign-in");
 		}
 	}, [isPending, session, router]);
 
-	// Show content immediately while checking
-	// This provides a much faster perceived load time
-	// The redirect will happen in background if not authenticated
-	if (!isPending && !session?.user) {
-		return null; // Will redirect
+	// HYDRATION FIX: Always render children on initial render to match server
+	// The redirect happens via useEffect, not conditional rendering
+	// Only hide content after we've confirmed redirect is needed (client-side only)
+	if (shouldRedirect) {
+		return null;
 	}
 
 	return <>{children}</>;

--- a/apps/web/src/components/dashboard-layout-inner.tsx
+++ b/apps/web/src/components/dashboard-layout-inner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import AppSidebar from "@/components/app-sidebar";
 import MobileDashboardNav from "@/components/mobile-dashboard-nav";
@@ -23,6 +23,12 @@ export default function DashboardLayoutClient({
   chats,
 }: DashboardLayoutClientProps) {
   const pathname = usePathname();
+  // HYDRATION FIX: Track mount state to ensure consistent server/client render
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   // Check if we're on a chat page and extract chatId
   const chatPageMatch = pathname?.match(/^\/dashboard\/chat\/([^/]+)$/);
@@ -49,17 +55,19 @@ export default function DashboardLayoutClient({
         tabIndex={-1}
       >
         <DashboardControls />
-        {/* Mobile navigation button */}
-        <div className="pointer-events-auto absolute right-3 top-3 z-20 flex items-center gap-1 md:hidden">
-          {isOnChatPage && chatId && (
+        {/* Mobile navigation button - only show after mount to prevent hydration mismatch */}
+        {isMounted && (
+          <div className="pointer-events-auto absolute right-3 top-3 z-20 flex items-center gap-1 md:hidden">
+            {isOnChatPage && chatId && (
+              <div className="rounded-lg border border-border/40 bg-background/80 backdrop-blur-sm shadow-sm">
+                <ChatExportButton chatId={chatId} />
+              </div>
+            )}
             <div className="rounded-lg border border-border/40 bg-background/80 backdrop-blur-sm shadow-sm">
-              <ChatExportButton chatId={chatId} />
+              <MobileDashboardNav initialChats={chats} />
             </div>
-          )}
-          <div className="rounded-lg border border-border/40 bg-background/80 backdrop-blur-sm shadow-sm">
-            <MobileDashboardNav initialChats={chats} />
           </div>
-        </div>
+        )}
         <div className="flex h-full w-full flex-1 flex-col overflow-x-hidden min-h-0">
           {children}
         </div>


### PR DESCRIPTION
## Summary
- Fix hydration mismatch in `AuthGuard` component where server rendered `null` but client rendered children due to `useSession()` returning different values
- Fix hydration mismatch in `DashboardLayoutClient` by deferring mobile navigation rendering until after mount

## Root Cause
The `useSession()` hook from better-auth returns different values on server vs client:
- **Server**: `{ isPending: false, data: null }` (no session available during SSR)
- **Client**: `{ isPending: true, data: null }` (loading from localStorage)

This caused `AuthGuard` to return `null` on server but `children` on client, triggering React hydration errors like:
```
+<a>
  +href="#main-content"
```

## Changes
1. **auth-guard.tsx**: Use `shouldRedirect` state instead of direct conditional return to ensure children are always rendered initially
2. **dashboard-layout-inner.tsx**: Add `isMounted` state to defer mobile navigation rendering until after hydration

## Test plan
- [x] Build passes locally (`bunx next build`)
- [x] Tested with Playwright - 0 hydration errors
- [ ] Verify on Vercel preview deployment
- [ ] Test: send message → reload page → check for hydration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)