### PR TITLE
fix(auth): force dynamic rendering for sign-in page

### DIFF
--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -3,6 +3,10 @@ import { Github, MessageSquare, Users, Sparkles } from "@/lib/icons";
 import Link from "next/link";
 import { Logo } from "@/components/logo";
 
+// Force dynamic rendering to ensure env vars are read at request time
+// This prevents ISR from caching a "not configured" state during builds
+export const dynamic = "force-dynamic";
+
 // Google icon component (not available in lucide-react)
 function GoogleIcon({ className }: { className?: string }) {
 	return (


### PR DESCRIPTION
## Summary
- Add `export const dynamic = 'force-dynamic'` to sign-in page
- This forces the page to render at request time instead of build time
- Fixes the "Authentication is not configured" issue that appears when env vars aren't available during build (e.g., canary deployments)

## Problem
The sign-in page was being statically generated during the build process. When env vars weren't available at build time (common in preview/canary deployments), the page would be cached with the "not configured" state.

## Solution
Force dynamic rendering ensures the page reads env vars at each request, so production deployments with proper env vars will work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)