### PR TITLE
fix(auth): add direct GitHub/Google OAuth buttons

### DIFF
--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -70,11 +70,16 @@ export default async function SignInPage() {
 	// If WorkOS is not configured, show a configuration required page
 	const isConfigured = clientId && redirectUri;
 
-	// Generate sign-in URL using AuthKit (handles state management properly)
-	let signInUrl = "#";
+	// Generate sign-in URLs using AuthKit (handles state management properly)
+	// Then modify the URL to go directly to specific OAuth providers
+	let githubSignInUrl = "#";
+	let googleSignInUrl = "#";
 
 	if (isConfigured) {
-		signInUrl = await getSignInUrl();
+		const baseUrl = await getSignInUrl();
+		// Replace provider=authkit with provider=GitHubOAuth/GoogleOAuth for direct OAuth
+		githubSignInUrl = baseUrl.replace("provider=authkit", "provider=GitHubOAuth");
+		googleSignInUrl = baseUrl.replace("provider=authkit", "provider=GoogleOAuth");
 	}
 
 	// Fetch stats in parallel (doesn't require WorkOS)
@@ -101,20 +106,23 @@ export default async function SignInPage() {
 						{isConfigured ? (
 							<>
 								<div className="space-y-3">
-									{/* Sign In Button - redirects to AuthKit hosted page */}
+									{/* GitHub Sign In Button */}
 									<a
-										href={signInUrl}
-										className="relative inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+										href={githubSignInUrl}
+										className="relative inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition hover:bg-accent hover:text-accent-foreground"
 									>
-										Sign In
+										<Github className="size-4" />
+										Continue with GitHub
 									</a>
-								</div>
 
-								<div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
-									<Github className="size-3.5" />
-									<span>•</span>
-									<GoogleIcon className="size-3.5" />
-									<span className="ml-1">OAuth available</span>
+									{/* Google Sign In Button */}
+									<a
+										href={googleSignInUrl}
+										className="relative inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition hover:bg-accent hover:text-accent-foreground"
+									>
+										<GoogleIcon className="size-4" />
+										Continue with Google
+									</a>
 								</div>
 
 								<p className="text-center text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Replace single "Sign In" button with direct "Continue with GitHub" and "Continue with Google" buttons
- Uses AuthKit's base URL but modifies the `provider` parameter to go directly to the OAuth provider
- Preserves AuthKit's state management for proper callback handling

## Changes
The sign-in page now shows:
- "Continue with GitHub" → Goes directly to GitHub OAuth authorization
- "Continue with Google" → Goes directly to Google OAuth authorization

This provides a better UX matching the development setup where users click their preferred provider and go directly to authorization.

## Also Fixed in WorkOS Dashboard
- Set "App homepage URL" to `https://osschat.dev` (fixes sign-out redirect error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)