### PR TITLE
revert(auth): use standard AuthKit flow for sign-in

### DIFF
--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -7,18 +7,6 @@ import { Logo } from "@/components/logo";
 // This prevents ISR from caching a "not configured" state during builds
 export const dynamic = "force-dynamic";
 
-// Google icon component (not available in lucide-react)
-function GoogleIcon({ className }: { className?: string }) {
-	return (
-		<svg className={className} viewBox="0 0 24 24" fill="currentColor">
-			<path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-			<path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-			<path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-			<path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-		</svg>
-	);
-}
-
 // Star icon for GitHub stars
 function StarIcon({ className }: { className?: string }) {
 	return (
@@ -70,16 +58,11 @@ export default async function SignInPage() {
 	// If WorkOS is not configured, show a configuration required page
 	const isConfigured = clientId && redirectUri;
 
-	// Generate sign-in URLs using AuthKit (handles state management properly)
-	// Then modify the URL to go directly to specific OAuth providers
-	let githubSignInUrl = "#";
-	let googleSignInUrl = "#";
+	// Generate sign-in URL using AuthKit (handles state management properly)
+	let signInUrl = "#";
 
 	if (isConfigured) {
-		const baseUrl = await getSignInUrl();
-		// Replace provider=authkit with provider=GitHubOAuth/GoogleOAuth for direct OAuth
-		githubSignInUrl = baseUrl.replace("provider=authkit", "provider=GitHubOAuth");
-		googleSignInUrl = baseUrl.replace("provider=authkit", "provider=GoogleOAuth");
+		signInUrl = await getSignInUrl();
 	}
 
 	// Fetch stats in parallel (doesn't require WorkOS)
@@ -105,25 +88,12 @@ export default async function SignInPage() {
 
 						{isConfigured ? (
 							<>
-								<div className="space-y-3">
-									{/* GitHub Sign In Button */}
-									<a
-										href={githubSignInUrl}
-										className="relative inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition hover:bg-accent hover:text-accent-foreground"
-									>
-										<Github className="size-4" />
-										Continue with GitHub
-									</a>
-
-									{/* Google Sign In Button */}
-									<a
-										href={googleSignInUrl}
-										className="relative inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition hover:bg-accent hover:text-accent-foreground"
-									>
-										<GoogleIcon className="size-4" />
-										Continue with Google
-									</a>
-								</div>
+								<a
+									href={signInUrl}
+									className="relative inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition hover:bg-accent hover:text-accent-foreground"
+								>
+									Sign In
+								</a>
 
 								<p className="text-center text-xs text-muted-foreground">
 									By continuing, you agree to our Terms of Service and Privacy Policy


### PR DESCRIPTION
## Summary
- Reverts direct OAuth provider URLs (GitHubOAuth/GoogleOAuth) back to the standard AuthKit hosted page flow
- The direct provider approach was causing SSO errors
- Uses a single "Sign In" button that redirects to AuthKit hosted page

## Test plan
- [ ] Verify sign-in page shows single "Sign In" button
- [ ] Click Sign In → should redirect to AuthKit hosted page
- [ ] AuthKit page should show GitHub/Google options
- [ ] Complete OAuth flow → should redirect back to app

🤖 Generated with [Claude Code](https://claude.com/claude-code)