### PR TITLE
fix(auth): handle WorkOS email verification for GitHub OAuth users

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "@vercel/speed-insights": "^1.2.0",
     "@workos-inc/authkit-nextjs": "^2.12.0",
+    "@workos-inc/node": "^7.77.0",
     "ai": "^5.0.44",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -1,5 +1,56 @@
-import { handleAuth } from '@workos-inc/authkit-nextjs';
+import { handleAuth, getWorkOS } from '@workos-inc/authkit-nextjs';
+import { NextResponse } from 'next/server';
 
 export const GET = handleAuth({
 	returnPathname: '/',
+	onSuccess: async ({ user, authenticationMethod }) => {
+		// Auto-verify email for OAuth users (GitHub/Google already verify emails)
+		// This prevents future issues with email verification requirements
+		const isOAuthMethod = authenticationMethod === 'GitHubOAuth' || authenticationMethod === 'GoogleOAuth';
+
+		if (user && !user.emailVerified && isOAuthMethod) {
+			try {
+				const workos = getWorkOS();
+				await workos.userManagement.updateUser({
+					userId: user.id,
+					emailVerified: true,
+				});
+				console.log(`[Auth] Auto-verified email for OAuth user: ${user.email}`);
+			} catch (error) {
+				console.error('[Auth] Failed to auto-verify user email:', error);
+			}
+		}
+	},
+	onError: async ({ error, request }) => {
+		// Handle email verification required error by redirecting to our verification page
+		const err = error as {
+			code?: string;
+			pendingAuthenticationToken?: string;
+			email?: string;
+			rawData?: {
+				code?: string;
+				pending_authentication_token?: string;
+				email?: string;
+			};
+		};
+
+		// Check for email_verification_required error (can be in error.code or error.rawData.code)
+		const errorCode = err?.code || err?.rawData?.code;
+		const token = err?.pendingAuthenticationToken || err?.rawData?.pending_authentication_token;
+		const email = err?.email || err?.rawData?.email;
+
+		if (errorCode === 'email_verification_required' && token && email) {
+			console.log(`[Auth] Email verification required for: ${email}`);
+			const verifyUrl = new URL('/auth/verify-email', request.url);
+			verifyUrl.searchParams.set('email', email);
+			verifyUrl.searchParams.set('token', token);
+			return NextResponse.redirect(verifyUrl);
+		}
+
+		// For other errors, redirect to sign-in with error message
+		console.error('[Auth] Authentication error:', error);
+		const signInUrl = new URL('/auth/sign-in', request.url);
+		signInUrl.searchParams.set('error', 'auth_failed');
+		return NextResponse.redirect(signInUrl);
+	},
 });

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,40 @@
+import { getWorkOS } from "@workos-inc/authkit-nextjs";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+	try {
+		const { email } = await request.json();
+
+		if (!email) {
+			return NextResponse.json(
+				{ error: "Email is required" },
+				{ status: 400 }
+			);
+		}
+
+		const workos = getWorkOS();
+
+		// Find the user by email
+		const users = await workos.userManagement.listUsers({ email });
+
+		if (users.data.length === 0) {
+			// Don't reveal if user exists or not
+			return NextResponse.json({ success: true });
+		}
+
+		const user = users.data[0];
+
+		// Send new verification email
+		await workos.userManagement.sendVerificationEmail({
+			userId: user.id,
+		});
+
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error("[Auth] Resend verification failed:", error);
+		return NextResponse.json(
+			{ error: "Failed to resend verification email" },
+			{ status: 500 }
+		);
+	}
+}

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,60 @@
+import { saveSession, getWorkOS } from "@workos-inc/authkit-nextjs";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+	try {
+		const { code, token } = await request.json();
+
+		if (!code || !token) {
+			return NextResponse.json(
+				{ error: "Verification code and token are required" },
+				{ status: 400 }
+			);
+		}
+
+		const workos = getWorkOS();
+
+		// Authenticate with the email verification code
+		const authResponse = await workos.userManagement.authenticateWithEmailVerification({
+			clientId: process.env.WORKOS_CLIENT_ID!,
+			code,
+			pendingAuthenticationToken: token,
+		});
+
+		// Save the session
+		await saveSession(
+			{
+				accessToken: authResponse.accessToken,
+				refreshToken: authResponse.refreshToken,
+				user: authResponse.user,
+				impersonator: authResponse.impersonator,
+			},
+			request
+		);
+
+		return NextResponse.json({ success: true, user: authResponse.user });
+	} catch (error: unknown) {
+		console.error("[Auth] Email verification failed:", error);
+
+		const err = error as { code?: string; message?: string };
+
+		if (err?.code === "invalid_code") {
+			return NextResponse.json(
+				{ error: "Invalid verification code. Please check and try again." },
+				{ status: 400 }
+			);
+		}
+
+		if (err?.code === "expired_token") {
+			return NextResponse.json(
+				{ error: "Verification code has expired. Please sign in again." },
+				{ status: 400 }
+			);
+		}
+
+		return NextResponse.json(
+			{ error: "Verification failed. Please try again." },
+			{ status: 500 }
+		);
+	}
+}

--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -62,9 +62,9 @@ async function fetchStats(): Promise<PublicStats | null> {
 }
 
 /**
- * Generate a direct OAuth sign-in URL for WorkOS
- *
- * This bypasses the AuthKit hosted page and goes directly to the provider's OAuth page
+ * Generate OAuth sign-in URL for WorkOS using direct API
+ * This goes directly to the provider's OAuth page, bypassing AuthKit UI
+ * AuthKit handles email verification in the callback automatically
  */
 function getDirectOAuthUrl(provider: "GitHubOAuth" | "GoogleOAuth"): string | null {
 	const clientId = process.env.WORKOS_CLIENT_ID;
@@ -91,6 +91,8 @@ export default async function SignInPage() {
 	const isConfigured = clientId && redirectUri;
 
 	// Generate direct OAuth URLs for each provider
+	// Note: GitHub OAuth is NOT auto-verified by WorkOS, so users may need to verify email
+	// The callback route handles this by redirecting to /auth/verify-email when needed
 	const githubUrl = getDirectOAuthUrl("GitHubOAuth");
 	const googleUrl = getDirectOAuthUrl("GoogleOAuth");
 

--- a/apps/web/src/app/auth/verify-email/page.tsx
+++ b/apps/web/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Logo } from "@/components/logo";
+import { useMounted } from "@/hooks/use-mounted";
+
+export default function VerifyEmailPage() {
+	const mounted = useMounted();
+	const router = useRouter();
+
+	const [code, setCode] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [email, setEmail] = useState<string | null>(null);
+	const [token, setToken] = useState<string | null>(null);
+
+	// Parse search params after mount to avoid hydration issues
+	useEffect(() => {
+		if (mounted && typeof window !== "undefined") {
+			const params = new URLSearchParams(window.location.search);
+			setEmail(params.get("email"));
+			setToken(params.get("token"));
+		}
+	}, [mounted]);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!code || !token) return;
+
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const response = await fetch("/api/auth/verify-email", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ code, token }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				setError(data.error || "Verification failed. Please try again.");
+				setIsLoading(false);
+				return;
+			}
+
+			// Success - redirect to home
+			router.push("/");
+		} catch {
+			setError("Something went wrong. Please try again.");
+			setIsLoading(false);
+		}
+	};
+
+	const handleResend = async () => {
+		if (!email) return;
+
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const response = await fetch("/api/auth/resend-verification", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ email }),
+			});
+
+			if (!response.ok) {
+				const data = await response.json();
+				setError(data.error || "Failed to resend code. Please try again.");
+			}
+		} catch {
+			setError("Something went wrong. Please try again.");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	if (!mounted) {
+		return (
+			<div className="flex min-h-svh items-center justify-center">
+				<div className="animate-pulse text-muted-foreground">Loading...</div>
+			</div>
+		);
+	}
+
+	if (!token) {
+		return (
+			<div className="flex min-h-svh flex-col items-center justify-center p-6">
+				<div className="w-full max-w-sm space-y-6 text-center">
+					<Logo size="small" className="mx-auto" />
+					<div className="space-y-2">
+						<h1 className="text-xl font-semibold">Invalid verification link</h1>
+						<p className="text-sm text-muted-foreground">
+							This verification link is invalid or has expired.
+						</p>
+					</div>
+					<Link
+						href="/auth/sign-in"
+						className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+					>
+						Back to Sign In
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex min-h-svh flex-col items-center justify-center p-6">
+			<div className="w-full max-w-sm space-y-6">
+				<div className="flex justify-center">
+					<Link href="/" className="transition-opacity hover:opacity-80">
+						<Logo size="small" />
+					</Link>
+				</div>
+
+				<div className="space-y-2 text-center">
+					<h1 className="text-xl font-semibold tracking-tight">Verify your email</h1>
+					<p className="text-sm text-muted-foreground">
+						We sent a verification code to{" "}
+						<span className="font-medium text-foreground">{email}</span>
+					</p>
+				</div>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<label htmlFor="code" className="text-sm font-medium">
+							Verification code
+						</label>
+						<input
+							id="code"
+							type="text"
+							inputMode="numeric"
+							pattern="[0-9]*"
+							maxLength={6}
+							value={code}
+							onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+							placeholder="Enter 6-digit code"
+							className="w-full rounded-md border border-input bg-background px-3 py-2 text-center text-lg tracking-widest placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+							autoComplete="one-time-code"
+							autoFocus
+						/>
+					</div>
+
+					{error && (
+						<div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+							{error}
+						</div>
+					)}
+
+					<button
+						type="submit"
+						disabled={code.length !== 6 || isLoading}
+						className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						{isLoading ? "Verifying..." : "Verify Email"}
+					</button>
+				</form>
+
+				<div className="text-center text-sm text-muted-foreground">
+					Didn't receive the code?{" "}
+					<button
+						onClick={handleResend}
+						disabled={isLoading}
+						className="font-medium text-primary hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						Resend
+					</button>
+				</div>
+
+				<div className="text-center">
+					<Link
+						href="/auth/sign-in"
+						className="text-sm text-muted-foreground hover:text-foreground"
+					>
+						← Back to Sign In
+					</Link>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "@tanstack/react-virtual": "^3.13.12",
         "@vercel/speed-insights": "^1.2.0",
         "@workos-inc/authkit-nextjs": "^2.12.0",
+        "@workos-inc/node": "^7.77.0",
         "ai": "^5.0.44",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2861,6 +2862,8 @@
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "web/@types/react": ["@types/react@19.1.17", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA=="],
+
+    "web/@workos-inc/node": ["@workos-inc/node@7.77.0", "", { "dependencies": { "iron-session": "~6.3.1", "jose": "~5.6.3", "leb": "^1.0.0", "qs": "6.14.0" } }, "sha512-6LGBAqih8kkzhHqmxueT9/xX93AJQxQhKekyNs0mqgWsrnqOPDiag1WIFzgxbQTvr564MqtEW502Tatfp1+x0Q=="],
 
     "web/react": ["react@19.1.2", "", {}, "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w=="],
 


### PR DESCRIPTION
## Summary
- Fix GitHub OAuth login by handling WorkOS email verification requirement
- Add email verification page with 6-digit code input UI
- Auto-verify OAuth users on successful authentication
- Redirect to verification page when email verification is required

## Problem
GitHub OAuth users couldn't sign in because WorkOS doesn't auto-verify GitHub emails (unlike Google OAuth with gmail.com). Users would get a JSON error with no way to verify their email.

## Solution
1. **Email verification page** (`/auth/verify-email`) - Clean UI for entering the 6-digit code
2. **Updated callback** - Intercepts `email_verification_required` error and redirects to verification page
3. **Auto-verify OAuth users** - For future-proofing, auto-verifies OAuth users on successful auth
4. **Resend endpoint** - API route to resend verification emails

## Technical Notes
- GitHub OAuth is NOT a trusted provider in WorkOS (requires email verification)
- Google OAuth with gmail.com domains ARE auto-verified
- Uses `useMounted` pattern to avoid Next.js hydration issues

## Test plan
- [ ] Test GitHub OAuth login for new user → should redirect to verification page
- [ ] Test entering verification code → should complete sign in
- [ ] Test Google OAuth login → should work without verification (for gmail.com emails)
- [ ] Test resend verification email

🤖 Generated with [Claude Code](https://claude.com/claude-code)