### PR TITLE
feat: add changelog button and AutoChangelog CI integration

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,9 +28,12 @@ This directory contains automated workflows for OpenChat's CI/CD pipeline.
 4. **Verify Deployment** - Confirms successful deployment
 5. **Run Migrations** - Executes database migrations automatically
 6. **Verify Data** - Checks data consistency post-migration
+7. **Generate Changelog** - Creates an AutoChangelog entry for the release
 
 **Environment Variables:**
 - `CONVEX_DEPLOY_KEY` - Required secret for Convex deployment authentication
+- `AUTOCHANGELOG_WEBHOOK_URL` - Optional: AutoChangelog webhook URL
+- `AUTOCHANGELOG_SECRET` - Optional: AutoChangelog webhook secret
 
 ### 3. Claude Code (`claude.yml`)
 
@@ -61,6 +64,20 @@ This is the deploy key for your Convex production deployment.
 2. Find the `CONVEX_DEPLOY_KEY` environment variable
 3. Copy the value
 4. Add it to GitHub Secrets
+
+#### `AUTOCHANGELOG_WEBHOOK_URL` & `AUTOCHANGELOG_SECRET` (Optional)
+
+These enable automatic changelog generation after each deployment via [AutoChangelog](https://autochangelog.com).
+
+**How to get them:**
+
+1. Go to [AutoChangelog Repositories](https://autochangelog.com/repositories)
+2. Find your repository (opentech1/openchat)
+3. Click "Installation Instructions"
+4. Copy the **Webhook URL** → add as `AUTOCHANGELOG_WEBHOOK_URL`
+5. Copy the **Webhook Secret** → add as `AUTOCHANGELOG_SECRET`
+
+The changelog will be auto-generated and published to [updates.osschat.dev](https://updates.osschat.dev/) after each successful deployment.
 
 ### Testing the Workflow
 
@@ -170,7 +187,8 @@ graph TD
     C --> D[Deploy Convex]
     D --> E[Run Migrations]
     E --> F[Verify Data]
-    A --> G[Vercel Auto-Deploy Web]
+    F --> G[Generate Changelog]
+    A --> H[Vercel Auto-Deploy Web]
 ```
 
 ## Security Best Practices

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -125,6 +125,48 @@ jobs:
           echo "2. Monitor deployment at dashboard link above"
           echo "3. Run manual smoke tests if needed"
 
+      - name: Generate changelog entry
+        if: success()
+        env:
+          AUTOCHANGELOG_WEBHOOK_URL: ${{ secrets.AUTOCHANGELOG_WEBHOOK_URL }}
+          AUTOCHANGELOG_SECRET: ${{ secrets.AUTOCHANGELOG_SECRET }}
+        run: |
+          echo "📝 Generating changelog entry..."
+
+          # Skip if secrets are not configured
+          if [ -z "$AUTOCHANGELOG_WEBHOOK_URL" ] || [ -z "$AUTOCHANGELOG_SECRET" ]; then
+            echo "⚠️  AutoChangelog secrets not configured, skipping changelog generation"
+            exit 0
+          fi
+
+          # Get the latest git tag for version, or use patch bump
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$VERSION" ]; then
+            BODY="{\"version\": \"$VERSION\"}"
+          else
+            BODY='{"bump": "patch"}'
+          fi
+
+          # Compute HMAC-SHA256 signature
+          SIGNATURE="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$AUTOCHANGELOG_SECRET" | cut -d' ' -f2)"
+
+          # Send webhook request
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$AUTOCHANGELOG_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Signature: $SIGNATURE" \
+            -d "$BODY")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ Changelog entry generated successfully"
+            echo "$RESPONSE_BODY"
+          else
+            echo "⚠️  Changelog generation returned HTTP $HTTP_CODE (non-fatal)"
+            echo "$RESPONSE_BODY"
+          fi
+
       - name: Notify on failure
         if: failure()
         run: |

--- a/apps/web/src/components/changelog-button.tsx
+++ b/apps/web/src/components/changelog-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Megaphone } from "@/lib/icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function ChangelogButton() {
+  return (
+    <a
+      href="https://updates.osschat.dev/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed top-6 right-6 z-50 hidden md:block"
+    >
+      <Button
+        size="icon"
+        variant="outline"
+        className={cn(
+          "size-12 rounded-full shadow-lg",
+          "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+          "hover:bg-accent hover:scale-105",
+          "transition-all duration-150"
+        )}
+        aria-label="View changelog and updates"
+      >
+        <Megaphone className="size-5" />
+      </Button>
+    </a>
+  );
+}

--- a/apps/web/src/components/dashboard-layout-inner.tsx
+++ b/apps/web/src/components/dashboard-layout-inner.tsx
@@ -6,6 +6,7 @@ import AppSidebar from "@/components/app-sidebar";
 import MobileDashboardNav from "@/components/mobile-dashboard-nav";
 import { DashboardControls } from "@/components/dashboard-controls";
 import { HelpButton } from "@/components/help-button";
+import { ChangelogButton } from "@/components/changelog-button";
 import { ChatExportButton } from "@/components/chat-export-button";
 
 type DashboardLayoutClientProps = {
@@ -90,6 +91,7 @@ export default function DashboardLayoutClient({
           {children}
         </div>
         <HelpButton />
+        <ChangelogButton />
       </main>
     </div>
   );

--- a/apps/web/src/lib/icons.ts
+++ b/apps/web/src/lib/icons.ts
@@ -113,6 +113,7 @@ export {
   Key,
   Link as LinkIcon,
   LogIn,
+  Megaphone,
   Rocket,
   Server,
   Wrench,


### PR DESCRIPTION
## Summary
- Add changelog button (megaphone icon) in dashboard top-right that opens https://updates.osschat.dev/
- Integrate AutoChangelog webhook into deploy-production workflow for automatic changelog generation
- Update workflow documentation with new steps and required secrets

## Changes
- `apps/web/src/components/changelog-button.tsx` - New changelog button component
- `apps/web/src/components/dashboard-layout-inner.tsx` - Add changelog button to layout
- `apps/web/src/lib/icons.ts` - Export Megaphone icon
- `.github/workflows/deploy-production.yml` - Add AutoChangelog webhook step
- `.github/workflows/README.md` - Document new workflow step and secrets

## Setup Required
Add these GitHub secrets for AutoChangelog to work:
- `AUTOCHANGELOG_WEBHOOK_URL`
- `AUTOCHANGELOG_SECRET`

## Test plan
- [x] Changelog button visible in top-right of dashboard
- [x] Button opens updates.osschat.dev in new tab
- [ ] Deployment workflow runs successfully
- [ ] AutoChangelog generates entry after deploy (requires secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)