### PR TITLE
fix: hardcode correct Convex URL in canary workflow

### DIFF
--- a/.github/workflows/prod-canary.yml
+++ b/.github/workflows/prod-canary.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Run canary tests
         env:
-          PROD_CONVEX_URL: ${{ secrets.CONVEX_URL }}
+          PROD_CONVEX_URL: "https://outgoing-setter-201.convex.cloud"
           CANARY_TIMEOUT_MS: "15000"
-          CANARY_MAX_RETRIES: "5"
-          CANARY_RETRY_DELAY_MS: "10000"
+          CANARY_MAX_RETRIES: "3"
+          CANARY_RETRY_DELAY_MS: "5000"
         run: bun ./scripts/prod-canary.ts


### PR DESCRIPTION
The CONVEX_URL secret was pointing to a wrong/old deployment causing the canary to hang for 5+ minutes.

- Hardcoded the correct production URL
- Reduced retries from 5→3 and delay from 10s→5s for faster execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)