### PR TITLE
fix: accept HTTP 201 as success for changelog

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -159,7 +159,7 @@ jobs:
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
 
-          if [ "$HTTP_CODE" = "200" ]; then
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ]; then
             echo "✅ Changelog entry generated successfully"
             echo "$RESPONSE_BODY"
           else


### PR DESCRIPTION
AutoChangelog returns 201 Created on success, not 200 OK. This prevents the misleading warning message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)