### PR TITLE
fix(server): configure explicit CORS origins for Better Auth

### DIFF
--- a/apps/server/convex/http.ts
+++ b/apps/server/convex/http.ts
@@ -8,7 +8,17 @@ import { authComponent, createAuth } from "./auth";
 const http = httpRouter();
 
 // Register Better Auth routes with CORS enabled for client-side requests
-authComponent.registerRoutes(http, createAuth, { cors: true });
+authComponent.registerRoutes(http, createAuth, {
+  cors: {
+    allowedOrigins: [
+      "http://localhost:3000",
+      "https://osschat.dev",
+      "https://beta.osschat.dev",
+    ],
+    allowedHeaders: ["content-type", "authorization", "better-auth-cookie"],
+    exposedHeaders: ["set-better-auth-cookie"],
+  },
+});
 
 http.route({
   path: "/health",


### PR DESCRIPTION
## Summary
Fixes CORS preflight failures on production by adding explicit allowed origins.

### Problem
The `cors: true` option for Better Auth wasn't including the `Access-Control-Allow-Origin` header in preflight responses, causing sign-in to fail on osschat.dev.

### Solution
Configure explicit `allowedOrigins` in the CORS config:
- `http://localhost:3000` (development)
- `https://osschat.dev` (production)
- `https://beta.osschat.dev` (beta)

### Testing
Verified CORS preflight now returns correct headers:
```
access-control-allow-origin: https://osschat.dev
```