### PR TITLE
feat: add theme switcher component

### DIFF
--- a/apps/web/src/components/theme-switcher.tsx
+++ b/apps/web/src/components/theme-switcher.tsx
@@ -1,0 +1,49 @@
+import { SunIcon, MoonIcon, MonitorIcon } from 'lucide-react'
+import { useTheme } from '@/providers/theme-provider'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+export function ThemeSwitcher() {
+  const { theme, setTheme, resolvedTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon" aria-label="Toggle theme">
+            {resolvedTheme === 'dark' ? (
+              <MoonIcon className="size-4" />
+            ) : (
+              <SunIcon className="size-4" />
+            )}
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" side="bottom" sideOffset={8}>
+        <DropdownMenuRadioGroup
+          value={theme}
+          onValueChange={(value) => setTheme(value as 'light' | 'dark' | 'system')}
+        >
+          <DropdownMenuRadioItem value="light">
+            <SunIcon className="size-4" />
+            Light
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="dark">
+            <MoonIcon className="size-4" />
+            Dark
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="system">
+            <MonitorIcon className="size-4" />
+            System
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import {
 import { AppSidebar } from '../components/app-sidebar'
 import { useAuth } from '../lib/auth-client'
 import { usePostHogPageView } from '../providers/posthog'
+import { ThemeSwitcher } from '../components/theme-switcher'
 
 import appCss from '../styles.css?url'
 
@@ -88,6 +89,9 @@ function AppShell() {
     // No sidebar layout for unauthenticated users
     return (
       <>
+        <div className="fixed right-4 top-4 z-50">
+          <ThemeSwitcher />
+        </div>
         <Outlet />
         <CommandPalette />
       </>
@@ -101,6 +105,9 @@ function AppShell() {
       <div className="flex h-screen w-full bg-sidebar">
         <AppSidebar />
         <SidebarInset>
+          <div className="fixed right-4 top-4 z-50">
+            <ThemeSwitcher />
+          </div>
           <Outlet />
         </SidebarInset>
       </div>


### PR DESCRIPTION
## What changed

Added a theme switcher component in the top-right corner of all pages that allows users to toggle between light, dark, and system theme modes. The switcher displays a sun/moon icon based on the current theme and provides a dropdown menu with all three theme options.

## Why

Users needed a visible UI control to switch between light and dark modes. While the theme provider infrastructure was already in place, there was no accessible way for users to change their theme preference. The switcher defaults to system theme and persists user preferences in localStorage.

---

This PR was created by [Graphite Agent](https://app.graphite.com/background-agents/opentech1/openchat/task/bgt_01kdy1aj51ehsbcrnts8tk8sgj)
