### PR TITLE
fix(ci): use railway link before domain/redeploy commands

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -61,18 +61,30 @@ jobs:
         working-directory: apps/server
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_PREVIEW_DEPLOY_KEY }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          GITHUB_CLIENT_ID: ${{ secrets.AUTH_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.AUTH_GITHUB_CLIENT_SECRET }}
         run: |
           echo "⚙️ Setting Convex environment variables..."
 
           PR_NUM=${{ github.event.pull_request.number }}
           RAILWAY_URL="https://web-openchat-pr-${PR_NUM}.up.railway.app"
 
+          # Core settings
           bunx convex env set SITE_URL "$RAILWAY_URL" --preview-name pr-${PR_NUM}
           bunx convex env set NEXT_PUBLIC_DEPLOYMENT "preview" --preview-name pr-${PR_NUM}
+
+          # Auth settings - must match production for oAuthProxy to work
+          bunx convex env set BETTER_AUTH_SECRET "$BETTER_AUTH_SECRET" --preview-name pr-${PR_NUM}
+          bunx convex env set GITHUB_CLIENT_ID "$GITHUB_CLIENT_ID" --preview-name pr-${PR_NUM}
+          bunx convex env set GITHUB_CLIENT_SECRET "$GITHUB_CLIENT_SECRET" --preview-name pr-${PR_NUM}
 
           echo "✅ Convex env vars set"
           echo "   SITE_URL: $RAILWAY_URL"
           echo "   NEXT_PUBLIC_DEPLOYMENT: preview"
+          echo "   BETTER_AUTH_SECRET: [set]"
+          echo "   GITHUB_CLIENT_ID: [set]"
+          echo "   GITHUB_CLIENT_SECRET: [set]"
 
       - name: Configure Railway Environment
         env:


### PR DESCRIPTION
## Summary

Fixes the Railway CLI commands in the preview deployment workflow.

The `railway domain` and `railway redeploy` commands don't accept `--environment` flag. Need to use `railway link` first to set the environment context, then subsequent commands operate on the linked environment.

## Changes

- Added new "Link Railway Environment" step that runs `railway link` with project, environment, and service
- Simplified `railway variables`, `railway domain`, and `railway redeploy` commands to use the linked context
- Increased wait time from 10s to 15s for Railway PR environment creation

## Test Plan

- [ ] Workflow runs successfully on this PR
- [ ] Custom domain is properly added
- [ ] Preview URL works

🤖 Generated with [Claude Code](https://claude.com/claude-code)