### PR TITLE
fix(auth): verify one-time token before fetching session

### DIFF
--- a/apps/web/src/lib/auth-client.tsx
+++ b/apps/web/src/lib/auth-client.tsx
@@ -188,9 +188,27 @@ export function StableAuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    // Only fetch once on mount
-    if (!fetchedRef.current) {
-      fetchedRef.current = true;
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const ott = urlParams.get("ott");
+
+    if (ott) {
+      authClient.crossDomain.oneTimeToken
+        .verify({ token: ott })
+        .then(() => {
+          const url = new URL(window.location.href);
+          url.searchParams.delete("ott");
+          window.history.replaceState({}, "", url.toString());
+        })
+        .catch((err: unknown) => {
+          console.error("Failed to verify one-time token:", err);
+        })
+        .finally(() => {
+          fetchSession();
+        });
+    } else {
       fetchSession();
     }
   }, [fetchSession]);


### PR DESCRIPTION
## Summary

Fixes the auth getting stuck after GitHub OAuth redirect. Users were seeing "Sign in with GitHub" even after successful authentication.

## Root Cause

The `crossDomain` plugin creates a one-time token (`ott`) after OAuth callback and redirects to the frontend with `?ott=token`. However, the `StableAuthProvider` was fetching the session immediately on mount **without verifying the ott token first**, causing auth to fail silently.

## Changes

- Check for `ott` parameter in URL on component mount
- Verify the token via `authClient.crossDomain.oneTimeToken.verify()` before fetching session
- Remove `ott` from URL after processing to prevent re-verification on refresh

## Testing

- [x] Type check passes (`bun check-types`)
- [x] Build succeeds (`bun run build` in apps/web)