### PR TITLE
feat(analytics): add OneDollarStats custom events

### DIFF
--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,39 @@
+declare global {
+	interface Window {
+		stonks?: {
+			event: (name: string, props?: Record<string, string>) => void;
+		};
+	}
+}
+
+function sendEvent(name: string, props?: Record<string, string>) {
+	if (typeof window !== "undefined" && window.stonks?.event) {
+		window.stonks.event(name, props);
+	}
+}
+
+export const analytics = {
+	modelSwitched: (modelId: string) => {
+		sendEvent("Model Switched", { model: modelId });
+	},
+
+	messageSent: (modelId: string) => {
+		sendEvent("Message Sent", { model: modelId });
+	},
+
+	chatCreated: () => {
+		sendEvent("Chat Created");
+	},
+
+	signedIn: () => {
+		sendEvent("Signed In");
+	},
+
+	thinkingModeChanged: (effort: string) => {
+		sendEvent("Thinking Mode Changed", { effort });
+	},
+
+	searchToggled: (enabled: boolean) => {
+		sendEvent("Search Toggled", { enabled: enabled ? "true" : "false" });
+	},
+};

--- a/apps/web/src/lib/auth-client.tsx
+++ b/apps/web/src/lib/auth-client.tsx
@@ -13,6 +13,7 @@ import {
   crossDomainClient,
 } from "@convex-dev/better-auth/client/plugins";
 import { env } from "./env";
+import { analytics } from "./analytics";
 
 const AUTH_SESSION_COOKIE = "ba_session";
 
@@ -198,6 +199,7 @@ export function StableAuthProvider({ children }: { children: ReactNode }) {
       authClient.crossDomain.oneTimeToken
         .verify({ token: ott })
         .then(() => {
+          analytics.signedIn();
           const url = new URL(window.location.href);
           url.searchParams.delete("ott");
           window.history.replaceState({}, "", url.toString());

--- a/apps/web/src/stores/model.ts
+++ b/apps/web/src/stores/model.ts
@@ -10,6 +10,7 @@ import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { initPricingLookup } from "./provider";
+import { analytics } from "@/lib/analytics";
 
 // ============================================================================
 // Types
@@ -496,7 +497,10 @@ export const useModelStore = create<ModelState>()(
       (set, get) => ({
         selectedModelId: "anthropic/claude-3.5-sonnet",
 
-        setSelectedModel: (modelId) => set({ selectedModelId: modelId }, false, "model/select"),
+        setSelectedModel: (modelId) => {
+          analytics.modelSwitched(modelId);
+          set({ selectedModelId: modelId }, false, "model/select");
+        },
 
         favorites: new Set<string>(),
 
@@ -520,8 +524,10 @@ export const useModelStore = create<ModelState>()(
         // Reasoning effort - default to 'none' (disabled)
         reasoningEffort: "none" as ReasoningEffort,
 
-        setReasoningEffort: (effort) =>
-          set({ reasoningEffort: effort }, false, "model/reasoningEffort"),
+        setReasoningEffort: (effort) => {
+          analytics.thinkingModeChanged(effort);
+          set({ reasoningEffort: effort }, false, "model/reasoningEffort");
+        },
 
         // Max steps for multi-step tool calls (always enabled, controls iterations)
         maxSteps: 5, // Default: 5 steps max for tools

--- a/apps/web/src/stores/provider.ts
+++ b/apps/web/src/stores/provider.ts
@@ -10,6 +10,7 @@
 
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
+import { analytics } from "@/lib/analytics";
 
 // Provider types - both use OpenRouter, just different API keys
 export type ProviderType = "osschat" | "openrouter";
@@ -158,19 +159,20 @@ export const useProviderStore = create<ProviderState>()(
 
         toggleWebSearch: () => {
           const state = get();
-          // Check search limit before enabling
           if (!state.webSearchEnabled && state.isSearchLimitReached()) {
-            return; // Can't enable if at limit
+            return;
           }
-          set({ webSearchEnabled: !state.webSearchEnabled }, false, "provider/toggleWebSearch");
+          const newValue = !state.webSearchEnabled;
+          analytics.searchToggled(newValue);
+          set({ webSearchEnabled: newValue }, false, "provider/toggleWebSearch");
         },
 
         setWebSearchEnabled: (enabled) => {
           const state = get();
-          // Check search limit before enabling
           if (enabled && state.isSearchLimitReached()) {
             return;
           }
+          analytics.searchToggled(enabled);
           set({ webSearchEnabled: enabled }, false, "provider/setWebSearch");
         },
 


### PR DESCRIPTION
## Summary

Adds OneDollarStats custom event tracking for key user interactions.

## Events Tracked

| Event | Properties | When |
|-------|-----------|------|
| Model Switched | `model` (model ID) | User selects a different model |
| Message Sent | `model` (model ID) | User sends a message |
| Chat Created | - | New chat is created |
| Signed In | - | User completes OAuth sign-in |
| Thinking Mode Changed | `effort` (none/low/medium/high) | User changes reasoning effort |
| Search Toggled | `enabled` (true/false) | User enables/disables web search |

## Changes

- Added `apps/web/src/lib/analytics.ts` - utility wrapper for OneDollarStats events
- Integrated analytics calls in:
  - `stores/model.ts` - model switch, thinking mode
  - `stores/provider.ts` - search toggle
  - `hooks/use-persistent-chat.ts` - message sent, chat created
  - `lib/auth-client.tsx` - sign in

## Testing

- [x] Type check passes