### PR TITLE
feat(web): Redesign model selector with T3 Chat-style layout

### DIFF
--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -5,8 +5,22 @@ import { useModels, useModelStore, getModelById } from "@/stores/model";
 import { fuzzyMatch } from "@/lib/fuzzy-search";
 import { SearchIcon, ChevronDownIcon, CheckIcon } from "@/components/icons";
 
-// Provider logo from models.dev
 function ProviderLogo({ providerId, className }: { providerId: string; className?: string }) {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center rounded bg-muted text-[10px] font-medium uppercase",
+          className || "size-4",
+        )}
+      >
+        {providerId.charAt(0)}
+      </div>
+    );
+  }
+
   return (
     <img
       alt={`${providerId} logo`}
@@ -14,55 +28,143 @@ function ProviderLogo({ providerId, className }: { providerId: string; className
       height={16}
       width={16}
       src={`https://models.dev/logos/${providerId}.svg`}
-      onError={(e) => {
-        // Fallback to first letter if logo not found
-        e.currentTarget.style.display = "none";
-      }}
+      onError={() => setHasError(true)}
     />
   );
 }
 
-// Model item component
+function BrainIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn("size-3.5", className)}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19 14.5M14.25 3.104c.251.023.501.05.75.082M19 14.5l-3.75 5.25m0 0l-3.75-3.75m3.75 3.75V21m-7.5-1.25l3.75-5.25m0 0L8 10.75m3.75 3.75H3"
+      />
+    </svg>
+  );
+}
+
+function EyeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn("size-3.5", className)}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}
+
+function StarIcon({ className, filled }: { className?: string; filled?: boolean }) {
+  return (
+    <svg
+      className={cn("size-3.5", className)}
+      viewBox="0 0 24 24"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+      />
+    </svg>
+  );
+}
+
 function ModelItem({
   model,
   isSelected,
   isHighlighted,
+  isFavorite,
   onSelect,
   onHover,
+  onToggleFavorite,
   dataIndex,
 }: {
   model: Model;
   isSelected: boolean;
   isHighlighted: boolean;
+  isFavorite: boolean;
   onSelect: () => void;
   onHover: () => void;
+  onToggleFavorite: (e: React.MouseEvent) => void;
   dataIndex: number;
 }) {
+  const hasVision = model.modality?.includes("image");
+  const hasReasoning = model.reasoning;
+
   return (
     <button
       data-index={dataIndex}
       onClick={onSelect}
       onMouseEnter={onHover}
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2.5 rounded-xl py-2 pl-3 pr-8 text-left text-sm outline-none transition-colors",
-        isHighlighted ? "bg-accent text-accent-foreground" : "bg-transparent text-foreground",
+        "group relative flex w-full cursor-default items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm outline-none transition-all duration-150",
+        isHighlighted ? "bg-accent/80" : "hover:bg-accent/40",
       )}
     >
-      <ProviderLogo providerId={model.providerId} />
-      <span className="flex-1 truncate">{model.name}</span>
-      {model.isFree && (
-        <span className="text-caption font-medium text-success uppercase">Free</span>
-      )}
-      {isSelected && (
-        <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center text-primary">
-          <CheckIcon />
-        </span>
-      )}
+      <ProviderLogo providerId={model.providerId} className="size-4 shrink-0" />
+      <span className={cn("flex-1 truncate font-medium", isSelected && "text-primary")}>
+        {model.name}
+      </span>
+
+      <div className="flex items-center gap-1">
+        {hasReasoning && (
+          <span className="text-amber-500" title="Reasoning capable">
+            <BrainIcon />
+          </span>
+        )}
+        {hasVision && (
+          <span className="text-sky-500" title="Vision capable">
+            <EyeIcon />
+          </span>
+        )}
+        {model.isFree && (
+          <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-emerald-500">
+            Free
+          </span>
+        )}
+
+        <button
+          onClick={onToggleFavorite}
+          className={cn(
+            "ml-0.5 rounded p-0.5 transition-colors",
+            isFavorite
+              ? "text-amber-400 hover:text-amber-300"
+              : "text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-amber-400",
+          )}
+          title={isFavorite ? "Remove from favorites" : "Add to favorites"}
+        >
+          <StarIcon filled={isFavorite} />
+        </button>
+
+        {isSelected && (
+          <span className="ml-0.5 text-primary">
+            <CheckIcon className="size-4" />
+          </span>
+        )}
+      </div>
     </button>
   );
 }
 
-// Props for the ModelSelector component
 interface ModelSelectorProps {
   value: string;
   onValueChange: (modelId: string) => void;
@@ -80,99 +182,83 @@ export function ModelSelector({
   const [query, setQuery] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [isClosing, setIsClosing] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
 
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // Load ALL models from OpenRouter
   const { models, isLoading } = useModels();
+  const { favorites, toggleFavorite, isFavorite } = useModelStore();
 
   const selectedModel = useMemo(() => getModelById(models, value), [models, value]);
 
-  // Filter models based on query
-  const filteredModels = useMemo(() => {
-    if (!query.trim()) return models;
-
-    return models.filter(
-      (model) =>
-        fuzzyMatch(model.name, query) ||
-        fuzzyMatch(model.provider, query) ||
-        fuzzyMatch(model.id, query) ||
-        (model.family && fuzzyMatch(model.family, query)),
-    );
-  }, [models, query]);
-
-  // Separate popular and other models from filtered results
-  const { filteredPopular, filteredOthers } = useMemo(() => {
-    const popular: Array<Model> = [];
-    const others: Array<Model> = [];
-    for (const model of filteredModels) {
-      if (model.isPopular) {
-        popular.push(model);
+  const uniqueProviders = useMemo(() => {
+    const providerMap = new Map<string, { id: string; name: string; count: number }>();
+    for (const model of models) {
+      const existing = providerMap.get(model.providerId);
+      if (existing) {
+        existing.count++;
       } else {
-        others.push(model);
+        providerMap.set(model.providerId, {
+          id: model.providerId,
+          name: model.provider,
+          count: 1,
+        });
       }
     }
-    return { filteredPopular: popular, filteredOthers: others };
+    return Array.from(providerMap.values()).sort((a, b) => b.count - a.count);
+  }, [models]);
+
+  const filteredModels = useMemo(() => {
+    let result = models;
+
+    if (showFavoritesOnly) {
+      result = result.filter((m) => favorites.has(m.id));
+    }
+
+    if (selectedProvider) {
+      result = result.filter((m) => m.providerId === selectedProvider);
+    }
+
+    if (query.trim()) {
+      result = result.filter(
+        (model) =>
+          fuzzyMatch(model.name, query) ||
+          fuzzyMatch(model.provider, query) ||
+          fuzzyMatch(model.id, query) ||
+          (model.family && fuzzyMatch(model.family, query)),
+      );
+    }
+
+    return result;
+  }, [models, query, selectedProvider, showFavoritesOnly, favorites]);
+
+  const flatList = useMemo(() => {
+    const popularModels = filteredModels.filter((m) => m.isPopular);
+    const otherModels = filteredModels.filter((m) => !m.isPopular);
+    return [...popularModels, ...otherModels];
   }, [filteredModels]);
 
-  // Group other models by family/prefix
-  const groupedOtherModels = useMemo(() => {
-    const grouped: Record<string, Array<Model>> = {};
-    for (const model of filteredOthers) {
-      // Group by family if available, otherwise by ID prefix
-      const group = model.family || model.id.split("/")[0] || "Other";
-      const groupName = group.charAt(0).toUpperCase() + group.slice(1).replace(/-/g, " ");
-
-      if (!grouped[groupName]) {
-        grouped[groupName] = [];
-      }
-      grouped[groupName].push(model);
-    }
-    return grouped;
-  }, [filteredOthers]);
-
-  // Get visible groups sorted
-  const visibleGroups = useMemo(() => {
-    return Object.keys(groupedOtherModels).sort((a, b) => {
-      // Put larger groups first
-      const aLen = groupedOtherModels[a]?.length || 0;
-      const bLen = groupedOtherModels[b]?.length || 0;
-      if (aLen !== bLen) return bLen - aLen;
-      return a.localeCompare(b);
-    });
-  }, [groupedOtherModels]);
-
-  // Flat list for keyboard navigation
-  const flatList = useMemo(() => {
-    const result: Array<Model> = [];
-    result.push(...filteredPopular);
-    for (const group of visibleGroups) {
-      result.push(...groupedOtherModels[group]);
-    }
-    return result;
-  }, [filteredPopular, visibleGroups, groupedOtherModels]);
-
-  // Reset highlighted index when filtered list changes
   useEffect(() => {
     setHighlightedIndex(0);
-  }, [query]);
+  }, [query, selectedProvider, showFavoritesOnly]);
 
-  // Open handler
   const handleOpen = useCallback(() => {
     if (disabled) return;
     setOpen(true);
     setQuery("");
     setHighlightedIndex(0);
     setIsClosing(false);
+    setSelectedProvider(null);
+    setShowFavoritesOnly(false);
     requestAnimationFrame(() => {
       inputRef.current?.focus();
     });
   }, [disabled]);
 
-  // Close handler with animation
   const handleClose = useCallback(() => {
     setIsClosing(true);
     setTimeout(() => {
@@ -182,7 +268,6 @@ export function ModelSelector({
     }, 150);
   }, []);
 
-  // Select handler
   const handleSelect = useCallback(
     (modelId: string) => {
       onValueChange(modelId);
@@ -191,7 +276,14 @@ export function ModelSelector({
     [onValueChange, handleClose],
   );
 
-  // Keyboard navigation
+  const handleToggleFavorite = useCallback(
+    (e: React.MouseEvent, modelId: string) => {
+      e.stopPropagation();
+      toggleFavorite(modelId);
+    },
+    [toggleFavorite],
+  );
+
   useEffect(() => {
     if (!open) return;
 
@@ -226,7 +318,6 @@ export function ModelSelector({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [open, flatList, highlightedIndex, handleSelect, handleClose]);
 
-  // Scroll highlighted item into view
   useEffect(() => {
     if (!listRef.current || !open) return;
     const selectedElement = listRef.current.querySelector(`[data-index="${highlightedIndex}"]`);
@@ -235,7 +326,6 @@ export function ModelSelector({
     }
   }, [highlightedIndex, open]);
 
-  // Close on click outside
   useEffect(() => {
     if (!open) return;
 
@@ -254,17 +344,10 @@ export function ModelSelector({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [open, handleClose]);
 
-  // Get flat index for a model
-  const getFlatIndex = useCallback(
-    (modelId: string) => {
-      return flatList.findIndex((m) => m.id === modelId);
-    },
-    [flatList],
-  );
+  const hasFavorites = favorites.size > 0;
 
   return (
     <div className={cn("relative inline-block", className)}>
-      {/* Trigger button */}
       <button
         ref={triggerRef}
         type="button"
@@ -293,12 +376,11 @@ export function ModelSelector({
         <ChevronDownIcon />
       </button>
 
-      {/* Dropdown content */}
       {open && (
         <div
           ref={contentRef}
           className={cn(
-            "absolute left-0 top-full z-50 mt-1.5 w-[320px] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-2xl",
+            "absolute left-0 top-full z-50 mt-1.5 flex h-[420px] w-[400px] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-2xl",
             isClosing
               ? "animate-out fade-out-0 zoom-out-95 slide-out-to-top-2 duration-150"
               : "animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 duration-200",
@@ -306,120 +388,139 @@ export function ModelSelector({
           role="listbox"
           aria-label="Models"
         >
-          {/* Search input */}
-          <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-            <SearchIcon />
-            <input
-              ref={inputRef}
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search models..."
-              className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
-              autoComplete="off"
-              autoCorrect="off"
-              spellCheck={false}
-            />
+          <div className="flex w-12 shrink-0 flex-col items-center gap-1 border-r border-border bg-muted/30 py-2">
+            <button
+              onClick={() => {
+                setShowFavoritesOnly(!showFavoritesOnly);
+                setSelectedProvider(null);
+              }}
+              className={cn(
+                "flex size-8 items-center justify-center rounded-lg transition-all duration-150",
+                showFavoritesOnly
+                  ? "bg-amber-500/20 text-amber-400"
+                  : hasFavorites
+                    ? "text-muted-foreground hover:bg-accent hover:text-foreground"
+                    : "cursor-not-allowed text-muted-foreground/30",
+              )}
+              title={hasFavorites ? "Show favorites" : "No favorites yet"}
+              disabled={!hasFavorites}
+            >
+              <StarIcon filled={showFavoritesOnly} className="size-4" />
+            </button>
+
+            <div className="my-1 h-px w-6 bg-border" />
+
+            <div className="flex flex-1 flex-col gap-1 overflow-y-auto">
+              {uniqueProviders.slice(0, 15).map((provider) => (
+                <button
+                  key={provider.id}
+                  onClick={() => {
+                    setSelectedProvider(selectedProvider === provider.id ? null : provider.id);
+                    setShowFavoritesOnly(false);
+                  }}
+                  className={cn(
+                    "flex size-8 items-center justify-center rounded-lg transition-all duration-150",
+                    selectedProvider === provider.id
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                  )}
+                  title={provider.name}
+                >
+                  <ProviderLogo providerId={provider.id} className="size-4" />
+                </button>
+              ))}
+            </div>
           </div>
 
-          {/* Model list */}
-          <div ref={listRef} className="max-h-[400px] overflow-y-auto overscroll-contain p-1">
-            {isLoading ? (
-              <div className="px-3 py-6 text-center text-sm text-muted-foreground">
-                Loading models...
-              </div>
-            ) : flatList.length === 0 ? (
-              <div className="px-3 py-6 text-center text-sm text-muted-foreground">
-                No models found
-              </div>
-            ) : (
-              <>
-                {/* Popular Models Section */}
-                {filteredPopular.length > 0 && (
-                  <>
-                    <div className="px-3 py-2 text-caption font-semibold uppercase tracking-widest text-warning">
-                      Popular
-                    </div>
-                    {filteredPopular.map((model) => {
-                      const flatIndex = getFlatIndex(model.id);
-                      return (
-                        <ModelItem
-                          key={model.id}
-                          model={model}
-                          isSelected={model.id === value}
-                          isHighlighted={flatIndex === highlightedIndex}
-                          onSelect={() => handleSelect(model.id)}
-                          onHover={() => setHighlightedIndex(flatIndex)}
-                          dataIndex={flatIndex}
-                        />
-                      );
-                    })}
-                  </>
-                )}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+              <SearchIcon className="size-4 shrink-0" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={
+                  showFavoritesOnly
+                    ? "Search favorites..."
+                    : selectedProvider
+                      ? `Search ${uniqueProviders.find((p) => p.id === selectedProvider)?.name || "provider"}...`
+                      : "Search models..."
+                }
+                className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+                autoComplete="off"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+              {(selectedProvider || showFavoritesOnly || query) && (
+                <button
+                  onClick={() => {
+                    setSelectedProvider(null);
+                    setShowFavoritesOnly(false);
+                    setQuery("");
+                    inputRef.current?.focus();
+                  }}
+                  className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  title="Clear filters"
+                >
+                  <svg className="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
 
-                {/* All Models by Group */}
-                {visibleGroups.length > 0 && (
-                  <>
-                    <div
-                      className={cn(
-                        "px-3 py-2 text-caption font-semibold uppercase tracking-widest text-muted-foreground/70",
-                        filteredPopular.length > 0 && "mt-2 border-t border-border pt-2",
-                      )}
+            <div ref={listRef} className="flex-1 overflow-y-auto overscroll-contain p-1.5">
+              {isLoading ? (
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  Loading models...
+                </div>
+              ) : flatList.length === 0 ? (
+                <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <span>No models found</span>
+                  {(selectedProvider || showFavoritesOnly) && (
+                    <button
+                      onClick={() => {
+                        setSelectedProvider(null);
+                        setShowFavoritesOnly(false);
+                        setQuery("");
+                      }}
+                      className="text-primary hover:underline"
                     >
-                      All Models
-                    </div>
-                    {visibleGroups.map((group: string) => (
-                      <div key={group} className="py-0.5">
-                        <div className="px-3 py-1 text-xs font-medium text-muted-foreground flex items-center gap-2">
-                          <ProviderLogo
-                            providerId={
-                              groupedOtherModels[group]?.[0]?.providerId || group.toLowerCase()
-                            }
-                            className="size-3"
-                          />
-                          {group}
-                        </div>
-                        {groupedOtherModels[group].map((model: Model) => {
-                          const flatIndex = getFlatIndex(model.id);
-                          return (
-                            <ModelItem
-                              key={model.id}
-                              model={model}
-                              isSelected={model.id === value}
-                              isHighlighted={flatIndex === highlightedIndex}
-                              onSelect={() => handleSelect(model.id)}
-                              onHover={() => setHighlightedIndex(flatIndex)}
-                              dataIndex={flatIndex}
-                            />
-                          );
-                        })}
-                      </div>
-                    ))}
-                  </>
-                )}
-              </>
-            )}
-          </div>
+                      Clear filters
+                    </button>
+                  )}
+                </div>
+              ) : (
+                flatList.map((model, index) => (
+                  <ModelItem
+                    key={model.id}
+                    model={model}
+                    isSelected={model.id === value}
+                    isHighlighted={index === highlightedIndex}
+                    isFavorite={isFavorite(model.id)}
+                    onSelect={() => handleSelect(model.id)}
+                    onHover={() => setHighlightedIndex(index)}
+                    onToggleFavorite={(e) => handleToggleFavorite(e, model.id)}
+                    dataIndex={index}
+                  />
+                ))
+              )}
+            </div>
 
-          {/* Footer with keyboard hints */}
-          <div className="flex items-center justify-between border-t border-border bg-muted/30 px-3 py-1.5">
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <span className="flex items-center gap-1">
-                <kbd className="inline-flex h-4 items-center rounded border border-border bg-muted px-1 font-mono text-caption">
+            <div className="flex items-center justify-between border-t border-border bg-muted/30 px-3 py-1.5">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <kbd className="inline-flex h-4 items-center rounded border border-border bg-muted px-1 font-mono text-[10px]">
                   ↑↓
                 </kbd>
-                <span>Navigate</span>
-              </span>
-              <span className="flex items-center gap-1">
-                <kbd className="inline-flex h-4 items-center rounded border border-border bg-muted px-1 font-mono text-caption">
+                <kbd className="inline-flex h-4 items-center rounded border border-border bg-muted px-1 font-mono text-[10px]">
                   ↵
                 </kbd>
-                <span>Select</span>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {flatList.length} model{flatList.length !== 1 ? "s" : ""}
               </span>
             </div>
-            <span className="text-xs text-muted-foreground">
-              {flatList.length} model{flatList.length !== 1 ? "s" : ""}
-            </span>
           </div>
         </div>
       )}
@@ -427,9 +528,6 @@ export function ModelSelector({
   );
 }
 
-/**
- * ModelSelector with built-in Zustand store connection
- */
 export function ConnectedModelSelector({
   className,
   disabled,


### PR DESCRIPTION
## Summary
- Redesigned model selector dropdown to match T3 Chat's modern two-column layout
- Added provider sidebar for quick filtering by AI provider
- Added favorites system with star toggle on each model row
- Compact rows with capability icons instead of verbose descriptions

## Changes
**Layout:**
- Two-column design: provider sidebar (48px) + model list
- Provider icons in left sidebar for one-click filtering
- Star icon at top for favorites-only view

**Model Rows:**
- Provider logo + model name (bold, truncates)
- 🧠 Brain icon (amber) for reasoning-capable models
- 👁 Eye icon (sky blue) for vision-capable models  
- "Free" badge (emerald) for free models
- ⭐ Star toggle (appears on hover, filled if favorited)
- ✓ Checkmark for currently selected model

**Preserved:**
- Keyboard navigation (↑↓ Enter Escape)
- Search/filter functionality
- External API (ModelSelector and ConnectedModelSelector props unchanged)

## Design Reference
Based on Theo's T3 Chat model selector design, adapted to use OpenChat's existing theme colors.