### PR TITLE
feat(web): Mobile UI Redesign

### DIFF
--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -163,15 +163,15 @@ export const ConversationScrollButton = ({
       type="button"
       className={cn(
         "absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full shadow-lg",
-        "flex size-9 items-center justify-center",
+        "flex size-11 md:size-9 items-center justify-center",
         "bg-background border border-border",
-        "hover:bg-muted transition-colors",
+        "hover:bg-muted active:scale-95 transition-all",
         className,
       )}
       onClick={handleScrollToBottom}
       {...props}
     >
-      <ArrowDownIcon className="size-4" />
+      <ArrowDownIcon className="size-5 md:size-4" />
     </button>
   );
 };

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -17,7 +17,7 @@ import {
   SidebarMenuButton,
   useSidebar,
 } from "./ui/sidebar";
-import { PlusIcon, ChatIcon, SidebarIcon, ChevronRightIcon } from "@/components/icons";
+import { PlusIcon, ChatIcon, SidebarIcon, ChevronRightIcon, MenuIcon } from "@/components/icons";
 import type { Id } from "@server/convex/_generated/dataModel";
 
 const CHATS_CACHE_KEY = "openchat-chats-cache";
@@ -172,16 +172,22 @@ export function AppSidebar() {
 
   return (
     <>
-      {/* Collapsed floating bar - aligns with sidebar header */}
+      {/* Mobile hamburger menu - CSS-based visibility (md:hidden), no JS required */}
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed left-3 top-3 z-50 flex size-11 items-center justify-center rounded-xl bg-sidebar/95 shadow-lg ring-1 ring-sidebar-border/50 backdrop-blur-sm text-sidebar-foreground/70 transition-all duration-200 hover:bg-sidebar hover:text-sidebar-foreground active:scale-95 md:hidden"
+        aria-label="Open menu"
+      >
+        <MenuIcon />
+      </button>
+
+      {/* Collapsed floating bar - desktop only, shows when sidebar is closed */}
       <div
         className={cn(
           "fixed left-3 top-3 z-50 flex items-center gap-1 rounded-xl bg-sidebar/95 p-1 shadow-lg ring-1 ring-sidebar-border/50 backdrop-blur-sm",
           "transition-[opacity,transform] duration-[220ms] ease-[cubic-bezier(0.25,0.1,0.25,1)]",
-          open && !isMobile
-            ? "pointer-events-none opacity-0 scale-95"
-            : !isMobile
-              ? "opacity-100 scale-100"
-              : "pointer-events-none opacity-0 scale-95",
+          "hidden md:flex",
+          open ? "pointer-events-none opacity-0 scale-95" : "opacity-100 scale-100",
         )}
       >
         <button

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -196,3 +196,21 @@ export function GitHubIcon({ className }: IconProps) {
 		</svg>
 	);
 }
+
+export function MenuIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth={2}
+				d="M4 6h16M4 12h16M4 18h16"
+			/>
+		</svg>
+	);
+}

--- a/apps/web/src/components/start-screen.tsx
+++ b/apps/web/src/components/start-screen.tsx
@@ -109,9 +109,9 @@ function CategoryPill({
     <button
       onClick={onClick}
       className={cn(
-        "flex items-center gap-2 px-4 py-2 rounded-full",
+        "flex items-center gap-1.5 md:gap-2 px-3 md:px-4 py-2.5 md:py-2 rounded-full",
         "text-sm font-medium",
-        "transition-all duration-200",
+        "transition-all duration-200 active:scale-95",
         isActive
           ? "bg-primary text-primary-foreground shadow-sm"
           : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",
@@ -129,9 +129,9 @@ function SuggestionItem({ text, onClick }: { text: string; onClick: () => void }
       onClick={onClick}
       className={cn(
         "group flex w-full items-center justify-between",
-        "px-4 py-3 rounded-xl",
-        "text-left text-[15px] text-foreground/80",
-        "bg-transparent hover:bg-muted/50",
+        "px-3 md:px-4 py-3.5 md:py-3 rounded-xl",
+        "text-left text-sm md:text-[15px] text-foreground/80",
+        "bg-transparent hover:bg-muted/50 active:bg-muted/70",
         "border border-transparent hover:border-border/30",
         "transition-all duration-200",
       )}
@@ -139,7 +139,7 @@ function SuggestionItem({ text, onClick }: { text: string; onClick: () => void }
       <span className="group-hover:text-foreground transition-colors">{text}</span>
       <ChevronRightIcon
         className={cn(
-          "size-4 text-muted-foreground/40 shrink-0 ml-3",
+          "size-4 text-muted-foreground/40 shrink-0 ml-2 md:ml-3",
           "opacity-0 group-hover:opacity-100",
           "translate-x-0 group-hover:translate-x-1",
           "transition-all duration-200",
@@ -182,21 +182,21 @@ export function StartScreen({ onPromptSelect, className }: StartScreenProps) {
       className={cn(
         "flex flex-col items-center",
         "w-full max-w-3xl mx-auto",
-        "pt-16 pb-8",
+        "pt-4 md:pt-16 pb-8",
         className,
       )}
     >
       {/* Greeting - Time-based with name */}
-      <div className="mb-8 text-center">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+      <div className="mb-6 md:mb-8 text-center px-2">
+        <h1 className="text-2xl md:text-3xl font-semibold tracking-tight text-foreground">
           {greeting}
           {firstName ? `, ${firstName}` : ""}
         </h1>
-        <p className="mt-2 text-base text-muted-foreground">How can I help you today?</p>
+        <p className="mt-1.5 md:mt-2 text-sm md:text-base text-muted-foreground">How can I help you today?</p>
       </div>
 
       {/* Category Pills - Selectable */}
-      <div className="mb-8 flex flex-wrap justify-center gap-2">
+      <div className="mb-6 md:mb-8 flex flex-wrap justify-center gap-1.5 md:gap-2 px-2">
         {CATEGORIES.map((category) => (
           <CategoryPill
             key={category.id}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -65,13 +65,20 @@ function SidebarProvider({
     setSidebarCollapsed,
   ]);
 
-  // Handle responsive breakpoint
+  // Handle responsive breakpoint - only auto-close when transitioning TO mobile
+  const wasMobileRef = React.useRef<boolean | null>(null);
+  
   React.useEffect(() => {
     const checkMobile = () => {
       const mobile = window.innerWidth < 768;
+      const wasMobile = wasMobileRef.current;
+      wasMobileRef.current = mobile;
+      
       setIsMobile(mobile);
-      // Auto-close on mobile
-      if (mobile && sidebarOpen) {
+      
+      // Only auto-close when TRANSITIONING from desktop to mobile while sidebar is open
+      // Don't close on every render or when user manually opens on mobile
+      if (mobile && !wasMobile && wasMobile !== null && sidebarOpen) {
         setSidebarOpen(false);
       }
     };


### PR DESCRIPTION
## Summary

Comprehensive mobile UI redesign fixing all reported mobile usability issues.

### Changes

- **Mobile Hamburger Menu**: Added hamburger button (`md:hidden`) that opens sidebar drawer on mobile
- **Model Selector Bottom Sheet**: Converted 420px dropdown to full-screen bottom sheet on mobile with horizontal scrollable provider filters
- **Responsive Prompt Input**: Footer now shows icon-only buttons on mobile for space efficiency
- **ModelConfigPopover Bottom Sheet**: Converted to bottom sheet on mobile
- **Touch Targets**: All interactive elements now have 44px minimum touch targets (iOS/Android HIG)
- **Safe Area Support**: Added `pb-safe` for iPhone notch/home indicator

### Critical Bug Fix

Fixed sidebar auto-close bug in `sidebar.tsx`. The original code had `sidebarOpen` in the effect's dependency array, causing the sidebar to immediately close when opened on mobile. Solution uses a ref to track previous mobile state and only auto-closes when *transitioning* from desktop to mobile.

### Files Modified

- `apps/web/src/components/app-sidebar.tsx`
- `apps/web/src/components/icons.tsx`
- `apps/web/src/components/model-selector.tsx`
- `apps/web/src/components/chat-interface.tsx`
- `apps/web/src/components/start-screen.tsx`
- `apps/web/src/components/ai-elements/conversation.tsx`
- `apps/web/src/components/ui/sidebar.tsx`

### Testing

- Build passes (`bun run build` in apps/web)
- Mobile breakpoint: 768px (Tailwind's `md:` breakpoint)