### PR TITLE
fix(web): add cache-busting for favicon and icons

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -3,22 +3,22 @@
   "name": "osschat",
   "icons": [
     {
-      "src": "favicon.ico",
+      "src": "favicon.ico?v=2",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "logo192.png?v=2",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "logo512.png?v=2",
       "type": "image/png",
       "sizes": "512x512"
     },
     {
-      "src": "apple-touch-icon.png",
+      "src": "apple-touch-icon.png?v=2",
       "type": "image/png",
       "sizes": "180x180"
     }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,17 +24,17 @@ export const Route = createRootRoute({
       { name: "description", content: "Open source AI chat powered by OpenRouter" },
       { property: "og:title", content: "osschat" },
       { property: "og:description", content: "Open source AI chat powered by OpenRouter" },
-      { property: "og:image", content: "/logo512.png" },
+      { property: "og:image", content: "/logo512.png?v=2" },
       { property: "og:type", content: "website" },
       { name: "twitter:card", content: "summary" },
       { name: "twitter:title", content: "osschat" },
       { name: "twitter:description", content: "Open source AI chat powered by OpenRouter" },
-      { name: "twitter:image", content: "/logo512.png" },
+      { name: "twitter:image", content: "/logo512.png?v=2" },
     ],
     links: [
       { rel: "stylesheet", href: appCss },
-      { rel: "icon", href: "/favicon.ico" },
-      { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
+      { rel: "icon", href: "/favicon.ico?v=2" },
+      { rel: "apple-touch-icon", href: "/apple-touch-icon.png?v=2" },
     ],
     scripts: [
       {


### PR DESCRIPTION
## Summary
- Add `?v=2` query parameter to favicon.ico and apple-touch-icon.png links
- Add cache-busting to og:image and twitter:image meta tags
- Update manifest.json icon sources with version parameter

## Problem
After the osschat rebrand (commit c974aaa), the new favicon wasn't showing in production even after hard refresh. Browsers aggressively cache favicons and often ignore standard cache invalidation.

## Solution
Add query parameter version strings (`?v=2`) to all icon/image URLs. This forces browsers to treat them as new resources, bypassing cached versions.

## Files Changed
- `apps/web/src/routes/__root.tsx` - favicon, apple-touch-icon, og:image, twitter:image
- `apps/web/public/manifest.json` - PWA icon sources

## Testing
- Build passes locally
- Type-check passes