### PR TITLE
fix(web): eliminate model selector flicker on rapid toggling

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -142,6 +142,7 @@
   }
   html {
     font-family: 'Nunito Sans Variable', ui-sans-serif, system-ui, sans-serif;
+    scrollbar-gutter: stable;
   }
   body {
     @apply bg-background text-foreground;
@@ -149,7 +150,10 @@
   }
 }
 
-/* Hide scrollbar but keep scrolling */
+[data-state="closed"] {
+  overflow: hidden !important;
+}
+
 @layer utilities {
   .scrollbar-none {
     -ms-overflow-style: none;
@@ -160,7 +164,6 @@
   }
 }
 
-/* Shimmer animation for reasoning/thinking text */
 @keyframes shimmer {
   0% {
     background-position: 200% 0;


### PR DESCRIPTION
## Summary
- Eliminates visual flicker when spam-clicking the model selector dropdown
- Fixes animation glitches that occurred during rapid open/close toggling

## Changes
- **CSS Transitions over Animations**: Replaced CSS animations (animate-in/animate-out) with CSS transitions for smoother, interruptible state changes
- **Persistent Portal Mounting**: Portal stays in DOM after first open (`hasEverOpened` pattern) to prevent unmount/remount flicker
- **Atomic State Updates**: Use `flushSync` to batch state changes and prevent intermediate renders
- **Pointer Events Control**: Add `pointer-events-none` when hidden to prevent interaction with invisible content
- **Layout Stability**: Add `scrollbar-gutter: stable` to prevent layout shifts
- **Clean Exit Animations**: Add `[data-state="closed"] { overflow: hidden }` for clean exit transitions

## Technical Details
The flicker was caused by:
1. Portal unmounting/remounting on rapid state changes
2. CSS animations restarting when classes changed mid-animation
3. React rendering intermediate states during rapid toggling

The fix follows patterns from production UI libraries (Radix UI, Headless UI):
1. Keep portal mounted to avoid DOM churn
2. Use CSS transitions which interpolate smoothly even when interrupted
3. Use `flushSync` for atomic state updates