### PR TITLE
fix: add explicit permissions blocks to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  checks: read
+
 jobs:
   # Wait for canary checks to pass before deploying
   wait-for-canary:

--- a/.github/workflows/prod-canary.yml
+++ b/.github/workflows/prod-canary.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   prod-canary:
     name: Run production canary checks

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
     },
     "apps/web": {
       "name": "web",
+      "version": "1.0.1",
       "dependencies": {
         "@ai-sdk/react": "^2.0.117",
         "@base-ui/react": "^1.0.0",


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to deploy-production and prod-canary workflows
- Resolve CodeQL security alerts for missing workflow permissions
- Follow principle of least privilege with minimal required permissions

## Changes
- `deploy-production.yml`: Added `contents: read` and `checks: read` permissions
- `prod-canary.yml`: Added `contents: read` permission

This remediates the missing workflow permissions security alerts from CodeQL.