### PR TITLE
Focus chat input on Ctrl/Cmd+L 

### DIFF
--- a/apps/web/src/routes/c/$chatId.tsx
+++ b/apps/web/src/routes/c/$chatId.tsx
@@ -5,7 +5,7 @@
  * Loads chat history and allows continuing the conversation.
  * Uses OSSChat Cloud (free tier) by default, no API key required.
  */
-
+import { useEffect } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useAuth } from "@/lib/auth-client";
 import { ChatInterface } from "@/components/chat-interface";
@@ -35,6 +35,37 @@ function ChatPage() {
       </div>
     );
   }
+  useEffect(() => {
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.defaultPrevented || e.repeat) return;
+
+    const isMac = navigator.platform.toUpperCase().includes("MAC");
+    const isShortcut =
+      (isMac && e.metaKey && e.key.toLowerCase() === "l") ||
+      (!isMac && e.ctrlKey && e.key.toLowerCase() === "l");
+
+    if (!isShortcut) return;
+
+    const active = document.activeElement as HTMLElement | null;
+    if (
+      active &&
+      (active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.isContentEditable)
+    ) {
+      return;
+    }
+
+    e.preventDefault();
+
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+    textarea?.focus();
+    textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
+  }
+
+  window.addEventListener("keydown", onKeyDown);
+  return () => window.removeEventListener("keydown", onKeyDown);
+}, []);
 
   return <ChatInterface chatId={chatId} />;
 }


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut on the chat page (`/c/:chatId`) so Ctrl/Cmd+L focuses the chat composer.

Impacted app: `apps/web`

## Related issue
Closes #328

## Testing
 -Manual: ran `bun dev` and verified the shortcut triggers a focus attempt on the chat page.
