### PR TITLE
fix(web): reset streaming UI state when background job completes

### DIFF
--- a/apps/web/src/hooks/use-persistent-chat.ts
+++ b/apps/web/src/hooks/use-persistent-chat.ts
@@ -150,7 +150,17 @@ export function usePersistentChat({
 	}, [messagesResult, status]);
 
 	useEffect(() => {
-		if (!activeStreamJob) return;
+		// getActiveStreamJob only returns "running"/"pending" jobs - null means completed
+		if (!activeStreamJob) {
+			if (status === "streaming" || status === "submitted") {
+				console.log("[BackgroundStream] Stream job completed, resetting UI state");
+				setStatus("ready");
+				streamingRef.current = null;
+				useStreamStore.getState().completeStream();
+			}
+			return;
+		}
+
 		if (activeStreamJob.status === "completed" || activeStreamJob.status === "error") {
 			if (status === "streaming") {
 				setStatus("ready");


### PR DESCRIPTION
## Summary
- Fixes the bug where the chat UI gets stuck in "streaming" state after a message completes
- The `getActiveStreamJob` Convex query only returns jobs with "running" or "pending" status
- When a job completes, it returns `null` - but the useEffect wasn't handling this case properly
- Now properly resets UI state to "ready" when `activeStreamJob` becomes `null`

## Root Cause
The useEffect in `use-persistent-chat.ts` had this logic:
```typescript
if (!activeStreamJob) return; // Just returned early, never reset status!
```

When the backend stream completed, `getActiveStreamJob` returned `null` (because it only queries running/pending jobs), but the UI status remained stuck at "streaming".

## Fix
Now when `activeStreamJob` becomes `null` AND status is still "streaming" or "submitted", we properly call `setStatus("ready")` and clean up the streaming state.

## Testing
1. Send a message in chat
2. Wait for it to complete
3. UI should properly reset to "ready" state (input enabled, thinking indicator gone)