### PR TITLE
fix: prevent settings header from overlapping status bar on mobile

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,7 +21,7 @@ export const Route = createRootRoute({
   head: () => ({
     meta: [
       { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { name: "viewport", content: "width=device-width, initial-scale=1, viewport-fit=cover" },
       { title: "osschat" },
       { name: "description", content: "Open source AI chat powered by OpenRouter" },
       { property: "og:title", content: "osschat" },

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -53,7 +53,7 @@ function SettingsPage() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
-      <header className="flex-none border-b bg-background">
+      <header className="flex-none border-b bg-background pt-[env(safe-area-inset-top)]">
         <div className="mx-auto max-w-3xl px-6">
           {/* Top row */}
           <div className="flex h-14 items-center justify-between">


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to enable safe area inset calculations on devices with notches/dynamic islands
- Add top safe-area padding to settings header to prevent overlap with device status bar

## Test plan
1. Run `bun run dev` in `apps/web`
2. Open the app on a mobile device or iOS simulator with notch/dynamic island
3. Navigate to Settings page
4. Verify the header content no longer overlaps with the status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)