### PR TITLE
fix: enable scrolling on legal pages

### DIFF
--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/about")({
 
 function AboutPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex h-full flex-col overflow-y-auto bg-background">
       {/* Header */}
       <header className="border-b">
         <div className="mx-auto max-w-3xl px-6 py-4">

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/privacy")({
 
 function PrivacyPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex h-full flex-col overflow-y-auto bg-background">
       {/* Header */}
       <header className="border-b">
         <div className="mx-auto max-w-3xl px-6 py-4">

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/terms")({
 
 function TermsPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex h-full flex-col overflow-y-auto bg-background">
       {/* Header */}
       <header className="border-b">
         <div className="mx-auto max-w-3xl px-6 py-4">


### PR DESCRIPTION
## Summary
Fixed scrolling on the terms, privacy, and about pages by changing the container layout from `min-h-screen` to `flex h-full flex-col overflow-y-auto`. This allows content to scroll properly when inside the constrained SidebarInset container.

## Changes
- Updated about.tsx, privacy.tsx, and terms.tsx with proper flex container and vertical scroll styling

🤖 Generated with Claude Code