### PR TITLE
fix: handle duplicate emails in user lookup

### DIFF
--- a/apps/server/convex/users.ts
+++ b/apps/server/convex/users.ts
@@ -81,13 +81,13 @@ export const ensure = mutation({
 			.withIndex("by_external_id", (q) => q.eq("externalId", args.externalId))
 			.unique();
 
-		// MIGRATION: If not found by externalId but email exists, try to link by email
-		// This handles users who previously logged in with WorkOS
+		// MIGRATION: Link WorkOS users to Better Auth by email
+		// Uses .first() since duplicate emails may exist from prior migrations
 		if (!existing && args.email) {
 			const existingByEmail = await ctx.db
 				.query("users")
 				.withIndex("by_email", (q) => q.eq("email", args.email))
-				.unique();
+				.first();
 
 			if (existingByEmail) {
 				// Update externalId to Better Auth user ID (migration from WorkOS)


### PR DESCRIPTION
## Problem
Production error: `unique() query returned more than one result from table users`

The `ensure` mutation was using `.unique()` when looking up users by email during auth migration, but duplicate emails exist from prior WorkOS migrations.

## Fix
Use `.first()` instead of `.unique()` - we just need the first matching user for the migration link.

## Impact
Fixes login failures for users with duplicate email entries.