### PR TITLE
feat(server): reasoning streaming + dynamic model capabilities

### DIFF
--- a/apps/server/convex/backgroundStream.ts
+++ b/apps/server/convex/backgroundStream.ts
@@ -303,6 +303,38 @@ export const executeStream = internalAction({
 			const controller = new AbortController();
 			const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
+			const requestBody: Record<string, unknown> = {
+				model: job.model,
+				messages: job.messages.map((m: { role: string; content: string }) => ({
+					role: m.role,
+					content: m.content,
+				})),
+				stream: true,
+			};
+
+			const reasoningEffort = job.options?.reasoningEffort;
+			if (reasoningEffort && reasoningEffort !== "none") {
+				const isAlwaysReasoning = /deepseek.*r1/i.test(job.model);
+				if (!isAlwaysReasoning) {
+					const effortToMaxTokens: Record<string, number> = {
+						low: 4096,
+						medium: 10000,
+						high: 20000,
+					};
+					const isAnthropicOrGemini = /^(anthropic|google)\//i.test(job.model);
+					if (isAnthropicOrGemini) {
+						const budgetTokens = effortToMaxTokens[reasoningEffort] || 10000;
+						requestBody.reasoning = { max_tokens: budgetTokens };
+						requestBody.max_tokens = budgetTokens + 8192;
+					} else {
+						requestBody.reasoning = { effort: reasoningEffort };
+						if (!requestBody.max_tokens) {
+							requestBody.max_tokens = 16384;
+						}
+					}
+				}
+			}
+
 			const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
 				method: "POST",
 				headers: {
@@ -311,14 +343,7 @@ export const executeStream = internalAction({
 					"HTTP-Referer": process.env.CONVEX_SITE_URL || "https://osschat.io",
 					"X-Title": "OSSChat",
 				},
-				body: JSON.stringify({
-					model: job.model,
-					messages: job.messages.map((m: { role: string; content: string }) => ({
-						role: m.role,
-						content: m.content,
-					})),
-					stream: true,
-				}),
+				body: JSON.stringify(requestBody),
 				signal: controller.signal,
 			});
 
@@ -365,13 +390,30 @@ export const executeStream = internalAction({
 					try {
 						const parsed = JSON.parse(data);
 						const delta = parsed.choices?.[0]?.delta;
-						
+
 						if (delta?.content) {
 							fullContent += delta.content;
 							updateCounter++;
 						}
-						if (delta?.reasoning) {
-							fullReasoning += delta.reasoning;
+
+						let reasoningText = "";
+						if (delta?.reasoning_details && Array.isArray(delta.reasoning_details) && delta.reasoning_details.length > 0) {
+							for (const detail of delta.reasoning_details) {
+								if (detail?.type === "reasoning.text" && detail.text) {
+									reasoningText += detail.text;
+								} else if (detail?.type === "reasoning.summary" && detail.summary) {
+									reasoningText += detail.summary;
+								}
+							}
+						}
+						if (!reasoningText && typeof delta?.reasoning === "string" && delta.reasoning) {
+							reasoningText = delta.reasoning;
+						}
+						if (!reasoningText && typeof delta?.reasoning_content === "string" && delta.reasoning_content) {
+							reasoningText = delta.reasoning_content;
+						}
+						if (reasoningText) {
+							fullReasoning += reasoningText;
 							updateCounter++;
 						}
 

--- a/apps/web/src/stores/model.ts
+++ b/apps/web/src/stores/model.ts
@@ -475,58 +475,26 @@ export const fallbackModels = getFallbackModels();
 
 export type ReasoningEffort = "none" | "low" | "medium" | "high";
 
-// Models that support reasoning with effort control
-// Based on OpenRouter API supported_parameters and model capabilities
-// See: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
-const REASONING_CAPABLE_MODELS = new Set([
-  // OpenAI o-series (reasoning models)
-  "openai/o1",
-  "openai/o1-mini",
-  "openai/o1-preview",
-  "openai/o3",
-  "openai/o3-mini",
-  "openai/o4-mini",
-  // GPT-5 series (all GPT-5 models are reasoning models)
-  "openai/gpt-5",
-  "openai/gpt-5-mini",
-  "openai/gpt-5-nano",
-  "openai/gpt-5-turbo",
-  // DeepSeek R1 (native reasoning)
-  "deepseek/deepseek-r1",
-  "deepseek/deepseek-r1-distill-llama-70b",
-  "deepseek/deepseek-r1-distill-qwen-32b",
-  "deepseek/deepseek-r1-distill-qwen-14b",
-  "deepseek/deepseek-r1-0528",
-  "deepseek/deepseek-r1:free",
-  // Anthropic Claude with extended thinking
-  "anthropic/claude-3.7-sonnet",
-  "anthropic/claude-3.7-sonnet:thinking",
-  "anthropic/claude-sonnet-4",
-  "anthropic/claude-sonnet-4:thinking",
-  // xAI Grok with reasoning
-  "x-ai/grok-3-mini-beta",
-  "x-ai/grok-3-mini",
-  // Google Gemini with thinking
-  "google/gemini-2.5-flash-preview-05-20",
-  "google/gemini-2.5-pro-preview-05-06",
-]);
+// ============================================================================
+// Dynamic Model Capabilities (API-driven, no hardcoded model lists)
+// ============================================================================
 
-// Check if a model supports reasoning effort control
-export function supportsReasoningEffort(modelId: string): boolean {
-  // Direct match
-  if (REASONING_CAPABLE_MODELS.has(modelId)) return true;
+export interface ModelCapabilities {
+  supportsReasoning: boolean;
+  supportsEffortLevels: boolean;
+  alwaysReasons: boolean;
+}
 
-  // Pattern matching for variants
-  const patterns = [
-    /^openai\/o[134]-/,
-    /^openai\/gpt-5/,
-    /deepseek.*r1/i,
-    /:thinking$/,
-    /-r1$/,
-    /-r1-/,
-  ];
+export function getModelCapabilities(modelId: string, model?: Model | null): ModelCapabilities {
+  const supportsReasoning = model?.reasoning === true;
+  const alwaysReasons = /deepseek.*r1/i.test(modelId);
+  const supportsEffort = supportsReasoning && !alwaysReasons;
 
-  return patterns.some((pattern) => pattern.test(modelId));
+  return {
+    supportsReasoning,
+    supportsEffortLevels: supportsEffort,
+    alwaysReasons,
+  };
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add provider-specific reasoning request params to `backgroundStream.ts` (Anthropic/Google use `max_tokens`, OpenAI/Grok use `effort`)
- Parse `reasoning_details` array from OpenRouter streaming responses (handles `reasoning.text`, `reasoning.summary`, plus fallbacks to `delta.reasoning` and `delta.reasoning_content`)
- Add reasoning `state` management (`"streaming"` → `"done"`) in UI message parts so ChainOfThought auto-collapses correctly
- Remove empty reasoning parts on job completion (fixes empty thinking box for models like GPT-5 that reason internally but don't return tokens)
- Replace all hardcoded model lists (`REASONING_CAPABLE_MODELS`, `REASONING_HIDDEN_MODELS`, `ALWAYS_REASONING_MODELS`) with dynamic API-driven capability detection via `getModelCapabilities()`

## Changes
| File | What |
|------|------|
| `apps/server/convex/backgroundStream.ts` | Provider-specific reasoning params + `reasoning_details` response parsing |
| `apps/web/src/hooks/use-persistent-chat.ts` | Reasoning state lifecycle (`streaming` → `done`) + empty part cleanup |
| `apps/web/src/stores/model.ts` | Dynamic `getModelCapabilities()` using `model.reasoning` from OpenRouter API |

## How it works now
1. User sets reasoning effort → stored in zustand
2. `startBackgroundStream` passes effort to Convex
3. Backend detects provider: Anthropic/Google get `{ max_tokens: N }`, others get `{ effort: "medium" }`
4. Response parsing checks `reasoning_details[]` → `delta.reasoning` → `delta.reasoning_content`
5. Frontend shows "Thinking..." with state tracking, auto-collapses when done
6. If model doesn't return reasoning content (GPT-5, o-series), empty part is removed on completion