### PR TITLE
fix: security hardening and type safety improvements

### DIFF
--- a/apps/server/convex/http.ts
+++ b/apps/server/convex/http.ts
@@ -42,8 +42,6 @@ http.route({
       JSON.stringify({ 
         ok: true, 
         ts: new Date().toISOString(),
-        convexSiteUrl: process.env.CONVEX_SITE_URL,
-        siteUrl: process.env.SITE_URL,
       }),
       {
         status: 200,


### PR DESCRIPTION
## Summary
- Remove `convexSiteUrl` and `siteUrl` from `/health` endpoint response to avoid leaking environment info
- Replace all `as any` casts in `use-persistent-chat.ts` with proper `ReasoningPartWithState` interface and type guard helpers

**Dropped from original PR #560:** auth.ts origin changes (regression — main already uses wildcards intentionally, and the PR removed `*.convex.site` support needed for Convex dev cloud).

Replaces #560 (rebased cleanly onto current main).