### PR TITLE
feat(web): disable OSSChat Cloud on preview deployments

### DIFF
--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -24,3 +24,12 @@ export function validateEnv(): void {
 		throw new Error(`Missing required environment variables: ${errors.join(", ")}`);
 	}
 }
+
+const PRODUCTION_HOSTS = ["osschat.dev", "www.osschat.dev"];
+
+export function isPreviewDeployment(): boolean {
+	if (typeof window === "undefined") return false;
+	const hostname = window.location.hostname;
+	if (hostname === "localhost" || hostname === "127.0.0.1") return false;
+	return !PRODUCTION_HOSTS.includes(hostname);
+}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -14,7 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { authClient, signOut, useAuth } from "@/lib/auth-client";
 import { useOpenRouterKey } from "@/stores/openrouter";
-import { DAILY_LIMIT_CENTS, useProviderStore } from "@/stores/provider";
+import { DAILY_LIMIT_CENTS, useProviderStore, isPreviewDeployment } from "@/stores/provider";
 import { getCacheStatus, useModels } from "@/stores/model";
 import { useChatTitleStore } from "@/stores/chat-title";
 import { useUIStore } from "@/stores/ui";
@@ -389,14 +389,17 @@ function ProvidersSection() {
           AI Provider
         </h2>
         <div className="grid gap-3">
-          {/* OSSChat Cloud - Free Tier */}
+          {/* OSSChat Cloud - Free Tier (disabled on preview deployments) */}
           <button
-            onClick={() => setActiveProvider("osschat")}
+            onClick={() => !isPreviewDeployment() && setActiveProvider("osschat")}
+            disabled={isPreviewDeployment()}
             className={cn(
               "flex items-start gap-4 rounded-xl border p-4 text-left transition-all",
-              activeProvider === "osschat"
-                ? "border-primary bg-primary/5 ring-1 ring-primary/20"
-                : "border-border bg-card hover:border-primary/50",
+              isPreviewDeployment()
+                ? "cursor-not-allowed border-border bg-muted/50 opacity-60"
+                : activeProvider === "osschat"
+                  ? "border-primary bg-primary/5 ring-1 ring-primary/20"
+                  : "border-border bg-card hover:border-primary/50",
             )}
           >
             <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-blue-500 to-cyan-500">
@@ -419,7 +422,11 @@ function ProvidersSection() {
               <p className="text-sm text-muted-foreground">
                 350+ AI models with {DAILY_LIMIT_CENTS}¢ daily limit
               </p>
-              {activeProvider === "osschat" && (
+              {isPreviewDeployment() ? (
+                <p className="mt-2 text-xs text-warning">
+                  Not available on preview deployments. Please use your own OpenRouter API key.
+                </p>
+              ) : activeProvider === "osschat" ? (
                 <div className="mt-3 space-y-2">
                   <div className="flex items-center justify-between text-xs">
                     <span className="text-muted-foreground">Daily Usage</span>
@@ -448,9 +455,9 @@ function ProvidersSection() {
                     </p>
                   )}
                 </div>
-              )}
+              ) : null}
             </div>
-            {activeProvider === "osschat" && (
+            {activeProvider === "osschat" && !isPreviewDeployment() && (
               <svg
                 className="size-5 shrink-0 text-primary"
                 fill="none"


### PR DESCRIPTION
## Summary

Disables OSSChat Cloud (free tier) on preview deployments since they don't have `OPENROUTER_API_KEY` configured.

## Changes

- **`apps/web/src/lib/env.ts`**: Added `isPreviewDeployment()` helper that detects non-production URLs (anything not `osschat.dev`)
- **`apps/web/src/stores/provider.ts`**: 
  - Forces provider to `openrouter` (BYOK) on previews via `onRehydrateStorage`
  - Prevents switching to `osschat` provider on previews
- **`apps/web/src/routes/settings.tsx`**: Disables OSSChat Cloud option with explanatory message on previews

## Why

Preview deployments are for testing and don't have the server-side OpenRouter API key configured. Without this change, users would try to use OSSChat Cloud and get errors. Now they see a clear message to use their own API key.

## Testing

- On production (`osschat.dev`): OSSChat Cloud works normally
- On previews (`*.up.railway.app`): OSSChat Cloud is disabled, user must connect their OpenRouter account