### PR TITLE
Handle Preflight scan exit codes

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -13,5 +13,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Preflight scan
-        continue-on-error: true
-        run: npx @preflightsh/preflight scan --ci --format json
+        shell: bash
+        run: |
+          set +e
+          npx --yes @preflightsh/preflight@0.12.5 scan --ci --format json
+          status=$?
+          set -e
+
+          # Preflight uses exit code 1/2 for scan findings; only fail on unexpected runtime errors.
+          if [ "$status" -gt 2 ]; then
+            echo "::error::Preflight CLI failed unexpectedly (exit code $status)"
+            exit "$status"
+          fi
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Preflight reported findings (exit code $status)"
+          fi


### PR DESCRIPTION
Summary
- stabilize the preflight workflow to ignore expected finding exit codes while still surfacing runtime failures
- pin the Preflight CLI execution to the tested 0.12.5 version and add warnings so GH Actions logs show findings without failing the job

Testing
- Not run (not requested)

don't use emojis, don't put useless slop, short, correct, and all the information needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Preflight CI workflow so expected scan findings don’t fail the job, while unexpected runtime errors still do. Pins the Preflight CLI to v0.12.5 and adds clear GitHub log annotations.

- **Bug Fixes**
  - Treat exit codes 1–2 as findings (emit ::warning); fail only for exit codes >2 (emit ::error).
  - Pin Preflight CLI via npx --yes @preflightsh/preflight@0.12.5 and run under bash for controlled exit handling.
  - Keep JSON output so findings are visible in Actions logs.

<sup>Written for commit d197949f5046ef6d7141372db6c8acaaf38914ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

