### PR TITLE
fix(server): remove concurrent osschat stream restriction

### DIFF
--- a/apps/server/convex/backgroundStream.ts
+++ b/apps/server/convex/backgroundStream.ts
@@ -293,21 +293,6 @@ export const startStream = mutation({
 			if (usedCents >= DAILY_AI_LIMIT_CENTS) {
 				throw new Error("Daily usage limit reached. Connect your OpenRouter account to continue.");
 			}
-
-			// Prevent concurrent osschat streams per user (TOCTOU mitigation)
-			const runningOsschatJobs = await ctx.db
-				.query("streamJobs")
-				.withIndex("by_user", (q) => q.eq("userId", userId).eq("status", "running"))
-				.collect();
-			const pendingOsschatJobs = await ctx.db
-				.query("streamJobs")
-				.withIndex("by_user", (q) => q.eq("userId", userId).eq("status", "pending"))
-				.collect();
-			const activeOsschatCount = runningOsschatJobs.filter(j => j.provider === "osschat").length
-				+ pendingOsschatJobs.filter(j => j.provider === "osschat").length;
-			if (activeOsschatCount > 0) {
-				throw new Error("Please wait for your current request to finish before sending another.");
-			}
 		}
 
 		const existingActiveStream = await ctx.db

--- a/apps/server/convex/billingUsage.test.ts
+++ b/apps/server/convex/billingUsage.test.ts
@@ -419,8 +419,8 @@ describe("backgroundStream.startStream - daily limit enforcement", () => {
 		expect(jobId).toBeDefined();
 	});
 
-		test("rejects concurrent osschat streams for same user", async () => {
-			await asExternalId(t, externalId).mutation(api.backgroundStream.startStream, {
+		test("allows concurrent osschat streams across different chats", async () => {
+			const jobId1 = await asExternalId(t, externalId).mutation(api.backgroundStream.startStream, {
 				chatId,
 				userId,
 				messageId: "msg_4",
@@ -434,16 +434,17 @@ describe("backgroundStream.startStream - daily limit enforcement", () => {
 				title: "Test Chat 2",
 			});
 
-		await expect(
-			asExternalId(t, externalId).mutation(api.backgroundStream.startStream, {
+			const jobId2 = await asExternalId(t, externalId).mutation(api.backgroundStream.startStream, {
 				chatId: chatResult2.chatId,
 				userId,
 				messageId: "msg_5",
 				model: "test/model",
 				provider: "osschat",
 				messages: [{ role: "user", content: "Another message" }],
-			}),
-		).rejects.toThrow("Please wait for your current request to finish");
+			});
+
+			expect(jobId1).toBeDefined();
+			expect(jobId2).toBeDefined();
 	});
 
 	test("resets daily limit for a new date", async () => {


### PR DESCRIPTION
## Summary

- Remove the per-user concurrent OSSChat stream check that prevented users from sending multiple requests simultaneously
- Users can now have concurrent streams across different chats
- Updated test to verify concurrent streams are allowed instead of rejected

## Changes

- `apps/server/convex/backgroundStream.ts`: Removed the TOCTOU mitigation block that queried running/pending stream jobs and threw an error for concurrent OSSChat streams
- `apps/server/convex/billingUsage.test.ts`: Updated test from "rejects concurrent osschat streams" to "allows concurrent osschat streams across different chats"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the per-user OSSChat concurrent stream restriction so users can run multiple streams in different chats at the same time. This makes multi-chat workflows faster.

- **New Features**
  - Allow concurrent streams across chats by removing the per-user TOCTOU check in backgroundStream.
  - Updated tests to assert two concurrent OSSChat streams return job IDs instead of erroring.

<sup>Written for commit a53b025180cf91c32571eb42ac03978575b044d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

