### PR TITLE
Add Dockerfile-based Railway build for web

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,32 @@ apps/web/out
 
 # Convex local artifacts
 apps/server/.convex
+apps/server/**
+!apps/server/package.json
+!apps/server/convex/
+!apps/server/convex/_generated/
+!apps/server/convex/_generated/**
 
 # Misc
 .env.local
+.vercel
+.railway
+.sisyphus
+.playwright-mcp
+.next
+.turbo
+
+# Web local/build artifacts
+apps/web/.output
+apps/web/.tanstack
+apps/web/.vinxi
+apps/web/.nitro
+apps/web/dist
+apps/web/dist-ssr
+apps/web/count.txt
+apps/web/todos.json
+
+# Not needed for web service image context
+docs/**
+docs-site/**
+test/**

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,15 +11,15 @@
     "check-types": "tsc --noEmit || true",
     "test": "echo \"No Convex tests yet\""
   },
-	"dependencies": {
-		"@convex-dev/better-auth": "^0.10.10",
-		"@convex-dev/persistent-text-streaming": "^0.3.0",
-		"@convex-dev/rate-limiter": "^0.3.2",
-		"better-auth": "1.4.18",
-		"@openrouter/ai-sdk-provider": "2.1.1",
-		"@valyu/ai-sdk": "^1.0.3",
-		"convex": "^1.31.7"
-	},
+  "dependencies": {
+    "@convex-dev/better-auth": "^0.10.10",
+    "@convex-dev/persistent-text-streaming": "^0.3.0",
+    "@convex-dev/rate-limiter": "^0.3.2",
+    "better-auth": "1.4.18",
+    "@openrouter/ai-sdk-provider": "2.1.1",
+    "@valyu/ai-sdk": "^1.0.3",
+    "convex": "^1.31.7"
+  },
   "devDependencies": {
     "convex-test": "^0.0.41"
   }

--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -1,10 +1,17 @@
 [build]
-builder = "RAILPACK"
-buildCommand = "cd apps/web && bun run build"
-watchPatterns = ["apps/web/**", "apps/server/convex/**"]
+builder = "DOCKERFILE"
+dockerfilePath = "docker/web.railway.Dockerfile"
+watchPatterns = [
+	"apps/web/**",
+	"apps/server/convex/_generated/**",
+	"bun.lock",
+	"bunfig.toml",
+	"docker/web.railway.Dockerfile",
+	"package.json",
+	"turbo.json",
+]
 
 [deploy]
-startCommand = "cd apps/web && bun .output/server/index.mjs"
 healthcheckPath = "/"
 healthcheckTimeout = 30
 restartPolicyType = "always"

--- a/docker/web.railway.Dockerfile
+++ b/docker/web.railway.Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7
+
+FROM oven/bun:1.3.0 AS deps
+WORKDIR /app
+
+# Copy only manifests first so dependency install stays cached unless deps change.
+COPY bun.lock package.json bunfig.toml turbo.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY apps/server/package.json apps/server/package.json
+COPY apps/extension/package.json apps/extension/package.json
+
+RUN --mount=type=cache,id=openchat-web-bun,target=/root/.bun/install/cache \
+	bun install --frozen-lockfile --filter web
+
+FROM deps AS builder
+WORKDIR /app
+
+COPY tsconfig.base.json tsconfig.base.json
+COPY apps/web apps/web
+COPY apps/server/convex/_generated apps/server/convex/_generated
+
+RUN bun run --cwd apps/web build
+
+FROM oven/bun:1.3.0 AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOST=0.0.0.0
+
+COPY --from=builder /app/apps/web/.output ./apps/web/.output
+
+EXPOSE 3000
+CMD ["bun", "apps/web/.output/server/index.mjs"]


### PR DESCRIPTION
## Summary
- expand `.dockerignore` so unnecessary files aren’t shipped in the web image
- replace the Rapid build config in `apps/web/railway.toml` with a Dockerfile-based pipeline and tighter watch patterns
- introduce `docker/web.railway.Dockerfile` that caches dependencies via Bun layers and runs the bundled Nitro server

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Railway build for web to a Dockerfile-based pipeline with Bun layer caching. This speeds deploys, reduces image size, and runs the bundled Nitro server consistently.

- **Refactors**
  - Replace RAILPACK with Dockerfile in apps/web/railway.toml; add focused watch patterns.
  - Add docker/web.railway.Dockerfile to install deps (filtered to web), build, and run .output/server.
  - Expand .dockerignore to drop non-web artifacts; keep needed server convex/_generated and package.json.
  - Format-only changes in apps/server/package.json (no functional impact).

<sup>Written for commit c3658c4cea3434a6c3b698ef596262aa03570643. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

