### PR TITLE
fix(web): remove broken startCommand from railway.toml

### DIFF
--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -12,7 +12,6 @@ watchPatterns = [
 ]
 
 [deploy]
-startCommand = "HOST=0.0.0.0 PORT=${PORT:-3000} bun apps/web/.output/server/index.mjs"
 healthcheckPath = "/"
 healthcheckTimeout = 120
 restartPolicyType = "always"


### PR DESCRIPTION
## Summary

- Removes `startCommand` from `railway.toml` that was causing **"The executable host=0.0.0.0 could not be found"** deploy failure
- Railway's `startCommand` doesn't run through a shell, so `HOST=0.0.0.0 PORT=${PORT:-3000} bun ...` is interpreted as trying to execute a binary named `HOST=0.0.0.0`
- The Dockerfile already sets `ENV HOST=0.0.0.0`, `ENV PORT=3000`, and has the correct `CMD` — `startCommand` is redundant and breaks deployment

## Verified

- Local production build succeeds (`bun run --cwd apps/web build`)
- Server starts and responds HTTP 200 on `/` healthcheck path
- No `startCommand` needed — Dockerfile CMD handles startup correctly
- Railway injects its own `PORT` env var at runtime, overriding the Dockerfile default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the broken startCommand from apps/web/railway.toml to fix Railway deploys failing with “The executable host=0.0.0.0 could not be found.” Startup is handled by the Dockerfile (ENV HOST/PORT and CMD), so no startCommand is needed.

<sup>Written for commit 9ae50d140aa3c5df0555f2bf207dafc694f07ae7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

