### PR TITLE
fix(web): remove hardcoded PORT from Dockerfile to fix Railway healthcheck

### DIFF
--- a/docker/web.railway.Dockerfile
+++ b/docker/web.railway.Dockerfile
@@ -24,10 +24,13 @@ FROM oven/bun:1.3.0 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-ENV PORT=3000
+# HOST must be 0.0.0.0 so the server binds all interfaces inside the container.
+# Do NOT set PORT or EXPOSE here — Railway injects its own PORT at runtime and
+# uses that same value for healthcheck probes. Hardcoding PORT in the Dockerfile
+# causes a mismatch where Nitro binds to Railway's dynamic port but the
+# healthcheck probes the Dockerfile's static port, resulting in "service unavailable".
 ENV HOST=0.0.0.0
 
 COPY --from=builder /app/apps/web/.output ./apps/web/.output
 
-EXPOSE 3000
 CMD ["bun", "apps/web/.output/server/index.mjs"]


### PR DESCRIPTION
## Summary

- Removes `ENV PORT=3000` and `EXPOSE 3000` from `web.railway.Dockerfile`
- Keeps `ENV HOST=0.0.0.0` (needed for container interface binding)

## Root Cause

Railway injects its own `PORT` env var at runtime and uses that same value for healthcheck probes. The Dockerfile's `ENV PORT=3000` caused a **port mismatch**:

1. Railway injects `PORT=<dynamic>` at runtime (overrides Dockerfile ENV)
2. Nitro reads `process.env.PORT` → binds to Railway's dynamic port
3. But Railway's healthcheck probes based on the **service variable**, not the Dockerfile ENV
4. No service variable set → healthcheck can't find the server → "service unavailable"

This is why RAILPACK worked (no Dockerfile = no conflicting ENV) but DOCKERFILE builder didn't.

## Verified

- Server starts and responds HTTP 200 without PORT set (defaults to 3000)
- Server starts and responds HTTP 200 with PORT=43721 (simulating Railway's dynamic port)
- Both scenarios tested locally against the production build output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed hardcoded PORT and EXPOSE from the web Railway Dockerfile so the app uses Railway’s injected port and healthchecks hit the correct port. Kept HOST=0.0.0.0 to bind all interfaces.

<sup>Written for commit 406861830362df9a4b465016bf68ce997eeb079d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

