### PR TITLE
fix(web): force nitro bind to Railway port via entrypoint

### DIFF
--- a/docker/web.railway.Dockerfile
+++ b/docker/web.railway.Dockerfile
@@ -24,13 +24,10 @@ FROM oven/bun:1.3.0 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-# HOST must be 0.0.0.0 so the server binds all interfaces inside the container.
-# Do NOT set PORT or EXPOSE here — Railway injects its own PORT at runtime and
-# uses that same value for healthcheck probes. Hardcoding PORT in the Dockerfile
-# causes a mismatch where Nitro binds to Railway's dynamic port but the
-# healthcheck probes the Dockerfile's static port, resulting in "service unavailable".
-ENV HOST=0.0.0.0
 
 COPY --from=builder /app/apps/web/.output ./apps/web/.output
+COPY docker/web.railway.entrypoint.sh ./docker/web.railway.entrypoint.sh
 
-CMD ["bun", "apps/web/.output/server/index.mjs"]
+RUN chmod +x ./docker/web.railway.entrypoint.sh
+
+CMD ["./docker/web.railway.entrypoint.sh"]

--- a/docker/web.railway.entrypoint.sh
+++ b/docker/web.railway.entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eu
+
+PORT_TO_USE="${PORT:-3000}"
+
+echo "[railway-entrypoint] starting web with NITRO_HOST=0.0.0.0 NITRO_PORT=${PORT_TO_USE}"
+
+exec env NITRO_HOST=0.0.0.0 NITRO_PORT="${PORT_TO_USE}" bun apps/web/.output/server/index.mjs


### PR DESCRIPTION
## Summary
- add `docker/web.railway.entrypoint.sh` and run it as container CMD
- entrypoint sets `NITRO_HOST=0.0.0.0` and `NITRO_PORT=${PORT:-3000}` explicitly
- keeps Dockerfile simple and removes runtime ambiguity around env precedence

## Why
`OpenChat - web` commit status on latest merged deploy fix (`f372653`) still reports **Deployment failed** (healthcheck failure). This PR makes startup deterministic for Railway by forcing Nitro to bind the exact runtime `PORT` that Railway healthchecks.

## Verification
- local run with `PORT=43888` returns HTTP 200
- local run without `PORT` defaults to 3000 and returns HTTP 200
- startup logs confirm explicit `NITRO_HOST/NITRO_PORT` values used

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Nitro to bind to Railway’s runtime PORT via a small entrypoint script, making startup deterministic and fixing healthcheck failures. Simplifies the Dockerfile by moving host/port setup to the entrypoint and removing env precedence ambiguity.

- **Bug Fixes**
  - Add docker/web.railway.entrypoint.sh to set NITRO_HOST=0.0.0.0 and NITRO_PORT from PORT (default 3000) before starting the server.
  - Update docker/web.railway.Dockerfile to copy and run the entrypoint, removing the HOST env so binding is controlled by the entrypoint.

<sup>Written for commit 368d02047819642e7cfccf4b788ad62afb95ce8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

