### PR TITLE
fix(web): revert to known-good Railpack deploy config

### DIFF
--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -1,17 +1,10 @@
 [build]
-builder = "DOCKERFILE"
-dockerfilePath = "docker/web.railway.Dockerfile"
-watchPatterns = [
-	"apps/web/**",
-	"apps/server/convex/_generated/**",
-	"bun.lock",
-	"bunfig.toml",
-	"docker/web.railway.Dockerfile",
-	"package.json",
-	"turbo.json",
-]
+builder = "RAILPACK"
+buildCommand = "cd apps/web && bun run build"
+watchPatterns = ["apps/web/**", "apps/server/convex/**"]
 
 [deploy]
+startCommand = "cd apps/web && bun .output/server/index.mjs"
 healthcheckPath = "/"
 healthcheckTimeout = 120
 restartPolicyType = "always"


### PR DESCRIPTION
## Summary
- switch `apps/web/railway.toml` builder back to `RAILPACK`
- restore previously successful startup command: `cd apps/web && bun .output/server/index.mjs`
- keep `healthcheckTimeout = 120` for cold starts

## Why
We now have hard verification from GitHub commit statuses that recent DOCKERFILE-based changes continue to fail Railway healthchecks:
- `f372653` (`OpenChat - web`): **Deployment failed**
- `b9d3347` (`OpenChat - web`): **Deployment failed**

The last known successful runtime path for web is the Railpack config used by commit `6211fca`.

## Verification
- local build with railpack build command succeeds
- local runtime with restored start command returns HTTP 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert the web service on Railway to the last known-good Railpack setup to fix failing healthchecks. Use Railpack builder with explicit build/start commands and keep the 120s healthcheck timeout.

- **Bug Fixes**
  - Switch builder to RAILPACK with buildCommand and tighter watchPatterns.
  - Restore start command: cd apps/web && bun .output/server/index.mjs.

<sup>Written for commit c4ff1376900ff52e953854ce03ac0f33707b862e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

