### PR TITLE
fix(web): include dependency files in Railpack watch patterns

### DIFF
--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -1,7 +1,17 @@
 [build]
 builder = "RAILPACK"
 buildCommand = "cd apps/web && bun run build"
-watchPatterns = ["apps/web/**", "apps/server/convex/**"]
+watchPatterns = [
+	"apps/web/**",
+	"apps/server/convex/**",
+	"apps/web/package.json",
+	"apps/server/package.json",
+	"apps/extension/package.json",
+	"package.json",
+	"bun.lock",
+	"bunfig.toml",
+	"turbo.json",
+]
 
 [deploy]
 startCommand = "cd apps/web && bun .output/server/index.mjs"


### PR DESCRIPTION
## Summary
- keep `RAILPACK` builder and known-good start command
- expand `watchPatterns` to include dependency graph files:
  - `bun.lock`, `package.json`, `bunfig.toml`, `turbo.json`
  - app manifests (`apps/web/package.json`, `apps/server/package.json`, `apps/extension/package.json`)

## Root cause proven
Using Railway CLI logs on failed deploy `fbcd1ac9-...` showed:
`bun install --frozen-lockfile` -> `error: lockfile had changes, but lockfile is frozen`

That happened because previous Railpack watch patterns excluded lockfile/manifests, so Railway snapshotting reused stale dependency files while code changed.

## Why this should fix deploy
Railway now snapshots dependency files whenever they change, so frozen lockfile install has consistent inputs and can proceed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed Railway deploys by including bun.lock and package manifests in Railpack watch patterns so snapshots rebuild when dependencies change. Prevents frozen bun install errors and keeps the known-good Railpack build/start flow.

- **Bug Fixes**
  - Use Railpack builder with explicit build and start commands.
  - Expand watchPatterns to include dependency files (bun.lock, package.jsons across apps, bunfig.toml, turbo.json).
  - Watch the entire convex directory instead of only _generated.

<sup>Written for commit c167c50c8d6348f2b41cdbf0ec8bbad8605ad821. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

