### PR TITLE
fix: update packageManager to bun@1.3.5 to fix Railway frozen lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "overrides": {
     "@peculiar/asn1-schema": "2.6.0"
   },
-  "packageManager": "bun@1.3.0",
+  "packageManager": "bun@1.3.5",
   "private": true,
   "scripts": {
     "check": "turbo lint",


### PR DESCRIPTION
## Summary
- Updates `packageManager` from `bun@1.3.0` to `bun@1.3.5` in root `package.json`
- Fixes Railway Railpack build failure where `bun install --frozen-lockfile` fails because the lockfile was generated with bun 1.3.5 but Railpack was using bun 1.3.0 (from `packageManager` field), causing resolver mismatches

## Context
After PR #608 reverted to Railpack builder, Railway builds failed at the install step:
```
bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
```
This is because Railpack reads `packageManager` to determine which bun version to use for dependency installation.

## Verification
- `bun install --frozen-lockfile` passes locally with bun 1.3.5 ✅
- Single-line change, no risk to runtime behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated packageManager in package.json to bun@1.3.5 to match the lockfile and the version Railpack uses. Fixes Railway builds failing on bun install --frozen-lockfile due to resolver mismatch.

<sup>Written for commit 2d3defab4966c6877444139f09b26661f0244718. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

