### PR TITLE
Update AutoChangelog integration workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,7 +17,7 @@ This directory contains automated workflows for OpenChat's CI/CD pipeline.
 
 ### 2. Production Deployment (`deploy-production.yml`)
 
-**Trigger:** Push to `main` branch (after canary checks pass)
+**Trigger:** Push to `main` branch (after canary checks pass, including merges from PRs targeting `main`)
 
 **Purpose:** Automatically deploys Convex backend to production on main branch merges.
 
@@ -33,7 +33,8 @@ This directory contains automated workflows for OpenChat's CI/CD pipeline.
 **Environment Variables:**
 - `CONVEX_DEPLOY_KEY` - Required secret for Convex deployment authentication
 - `AUTOCHANGELOG_WEBHOOK_URL` - Optional: AutoChangelog webhook URL
-- `AUTOCHANGELOG_WEBHOOK_SECRET` - Optional: AutoChangelog webhook secret
+- `AUTOCHANGELOG_SECRET` - Optional: AutoChangelog signing secret (preferred)
+- `AUTOCHANGELOG_WEBHOOK_SECRET` - Optional: Legacy secret name also supported
 
 ### 3. Claude Code (`claude.yml`)
 
@@ -65,7 +66,7 @@ This is the deploy key for your Convex production deployment.
 3. Copy the value
 4. Add it to GitHub Secrets
 
-#### `AUTOCHANGELOG_WEBHOOK_URL` & `AUTOCHANGELOG_WEBHOOK_SECRET` (Optional)
+#### `AUTOCHANGELOG_WEBHOOK_URL` & `AUTOCHANGELOG_SECRET` (Optional, preferred)
 
 These enable automatic changelog generation after each deployment via [AutoChangelog](https://autochangelog.com).
 
@@ -75,7 +76,9 @@ These enable automatic changelog generation after each deployment via [AutoChang
 2. Find your repository (opentech1/openchat)
 3. Click "Installation Instructions"
 4. Copy the **Webhook URL** → add as `AUTOCHANGELOG_WEBHOOK_URL`
-5. Copy the **Webhook Secret** → add as `AUTOCHANGELOG_WEBHOOK_SECRET`
+5. Copy the **Webhook Secret** → add as `AUTOCHANGELOG_SECRET`
+
+Legacy compatibility: `AUTOCHANGELOG_WEBHOOK_SECRET` is also supported if you already use that name.
 
 The changelog will be auto-generated and published to [updates.osschat.dev](https://updates.osschat.dev/) after each successful deployment.
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -133,12 +133,18 @@ jobs:
         if: success()
         env:
           AUTOCHANGELOG_WEBHOOK_URL: ${{ secrets.AUTOCHANGELOG_WEBHOOK_URL }}
-          AUTOCHANGELOG_SECRET: ${{ secrets.AUTOCHANGELOG_WEBHOOK_SECRET }}
+          AUTOCHANGELOG_SECRET: ${{ secrets.AUTOCHANGELOG_SECRET }}
+          AUTOCHANGELOG_WEBHOOK_SECRET: ${{ secrets.AUTOCHANGELOG_WEBHOOK_SECRET }}
         run: |
           echo "📝 Generating changelog entry..."
 
+          # Support both secret names:
+          # - AUTOCHANGELOG_SECRET (preferred, matches AutoChangelog docs)
+          # - AUTOCHANGELOG_WEBHOOK_SECRET (legacy name used in this repo)
+          SIGNING_SECRET="${AUTOCHANGELOG_SECRET:-$AUTOCHANGELOG_WEBHOOK_SECRET}"
+
           # Skip if secrets are not configured
-          if [ -z "$AUTOCHANGELOG_WEBHOOK_URL" ] || [ -z "$AUTOCHANGELOG_SECRET" ]; then
+          if [ -z "$AUTOCHANGELOG_WEBHOOK_URL" ] || [ -z "$SIGNING_SECRET" ]; then
             echo "⚠️  AutoChangelog secrets not configured, skipping changelog generation"
             exit 0
           fi
@@ -152,7 +158,7 @@ jobs:
           fi
 
           # Compute HMAC-SHA256 signature
-          SIGNATURE="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$AUTOCHANGELOG_SECRET" | cut -d' ' -f2)"
+          SIGNATURE="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | cut -d' ' -f2)"
 
           # Send webhook request
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$AUTOCHANGELOG_WEBHOOK_URL" \

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -227,7 +227,7 @@ function HomePage() {
 
     const script = document.createElement('script');
     script.id = scriptId;
-    script.src = 'https://autochangelog.com/embed/opentech1/openchat/in-app.js';
+    script.src = 'https://autochangelog.com/embed/tryosschat/osschat/in-app.js';
     document.body.appendChild(script);
 
     return () => {


### PR DESCRIPTION
Summary:
- expand deploy production docs to describe the merged trigger and preferred signing secrets
- make the workflow prefer the new `AUTOCHANGELOG_SECRET` while falling back to the legacy name and skip run when secrets are missing
- load the correct AutoChangelog embed script for the OSS Chat project

Testing:
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved AutoChangelog integration: the deploy workflow now prefers AUTOCHANGELOG_SECRET with a safe fallback and skips changelog generation when secrets are missing. Also fixed the in-app changelog embed to point to the OSS Chat project and clarified the deploy trigger in docs.

- **Refactors**
  - Prefer AUTOCHANGELOG_SECRET; fall back to AUTOCHANGELOG_WEBHOOK_SECRET.
  - Skip changelog step if webhook URL or secret is not set.
  - Docs: trigger includes merges to main; updated secret naming guidance.

- **Bug Fixes**
  - Load the correct embed script: tryosschat/osschat.

<sup>Written for commit 1a26f502b2c00ae61f3af7fe8eb6701c6ece0ea1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

