### PR TITLE
docs: add Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,27 @@ bun run verify:prod
   - `git subtree push --prefix=docs-site https://github.com/tryosschat/docs.git main`
 - `docs-site/` is external Mintlify docs; `docs/` contains internal deployment docs.
 - `bunfig.toml` isolates Bun's own test discovery; use Vitest commands for project tests.
+
+## Cursor Cloud specific instructions
+
+### Environment
+- Bun is installed at `~/.bun/bin/bun`; ensure `~/.bun/bin` is on `PATH`.
+- Use `bun run test` (not bare `bun test`) to invoke the `vitest run --coverage` script from `package.json`. Bare `bun test` triggers Bun's built-in test runner, which fails because the `bunfig.toml` root (`.bun-tests/`) doesn't exist.
+- The `.env.local` files for `apps/web` and `apps/server` are not checked in. They must be created before starting dev servers. Minimal dev defaults: `VITE_CONVEX_URL=http://localhost:3210`, `VITE_CONVEX_SITE_URL=http://localhost:3210` in `apps/web/.env.local`.
+
+### Services
+| Service | Command | Notes |
+|---------|---------|-------|
+| Web (Vite dev) | `bun dev:web` or `cd apps/web && bunx vite dev` | Runs on port 3000 by default. SSR requires all route modules to load cleanly. |
+| Convex backend | `bun dev:server` | Requires Convex cloud credentials; connects to a remote Convex project. |
+| Extension | `bun dev:extension` | Optional; not needed for core chat flow. |
+
+### Verification commands
+- Lint: `bun check` (runs Oxlint via Turbo across all workspaces)
+- Tests: `bun run test` (Vitest with coverage)
+- Type check: `bun check-types` (runs `tsc --noEmit` in web and extension workspaces; server uses `|| true`)
+
+### Known caveats
+- The Convex backend (`bun dev:server`) requires a Convex cloud project. Without one, the backend won't start. Auth features (GitHub OAuth) also require Convex environment variables (`AUTH_GITHUB_ID`, `AUTH_GITHUB_SECRET`, `BETTER_AUTH_SECRET`).
+- Redis is optional for development; the `scripts/check-redis.ts` script gracefully skips when Redis is unreachable in dev mode.
+- No Docker or local database is required; Convex is the sole data store.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud-specific development environment instructions to `AGENTS.md` so future cloud agents can properly set up and use the development environment.

### Changes
- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:
  - Environment setup (Bun path, env files)
  - Service table (web, Convex backend, extension)
  - Verification commands (lint, test, typecheck)
  - Known caveats (Convex cloud requirement, Redis optional, no Docker needed)

### Testing
- **Lint**: `bun check` — 3/3 workspaces pass (warnings only, 0 errors)
- **Tests**: `bun run test` — 100 test files, 2589 tests all passing
- **Type check**: `bun check-types` — passes for web and extension workspaces
- **Dev server**: `bun dev:web` (Vite v7.3.1) starts successfully on port 3000

### Notes
- The VM update script installs Bun v1.3.5 and runs `bun install`
- `.env.local` files are created at setup time (not committed)
- Pre-existing SSR issue noted: `apps/web/src/routes/share/$shareId.tsx` uses `.validator()` which was renamed to `.inputValidator()` in the locked `@tanstack/react-start@1.165.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-823b0cd2-a3c4-4db1-a384-b3e6ae40992a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-823b0cd2-a3c4-4db1-a384-b3e6ae40992a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor Cloud development environment setup instructions to AGENTS.md
> Adds a new 'Cursor Cloud specific instructions' section to [AGENTS.md](https://github.com/opencoredev/openchat/pull/702/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) covering setup steps, required environment variables, and known caveats for running the project in Cursor Cloud.
>
> - Documents Bun install path and PATH requirement, and the need to use `bun run test` instead of `bun test`
> - Provides minimal `.env.local` examples for `apps/web` and `apps/server` with Convex URL placeholders
> - Lists service start commands for Web (Vite dev), Convex backend, and Extension, plus verification commands for lint, tests, and type checks
> - Notes that Convex requires a cloud project, Redis is optional, and no Docker or local DB is needed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3647403.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->