### PR TITLE
Frontend quality: accessibility, loading UX, and chat error handling

### DIFF
--- a/apps/web/src/components/__tests__/chat-interface.test.tsx
+++ b/apps/web/src/components/__tests__/chat-interface.test.tsx
@@ -231,6 +231,7 @@ function makeDefaultState() {
 		chatId: null,
 		isResuming: false,
 		resumedContent: '',
+		resetChatError: vi.fn(),
 	}
 }
 

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -83,6 +83,7 @@ export const Conversation = ({ className, children, showScrollButton = false, ..
           ref={scrollRef}
           className="absolute inset-0 overflow-y-auto"
           role="log"
+          aria-label="Chat messages"
         >
           {children}
           {/* Anchor element for scroll-to-bottom */}
@@ -92,10 +93,11 @@ export const Conversation = ({ className, children, showScrollButton = false, ..
         {showScrollButton && !isAtBottom && (
           <button
             type="button"
+            aria-label="Scroll to latest message"
             className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 rounded-full shadow-lg flex size-11 md:size-9 items-center justify-center bg-background border border-border hover:bg-muted active:scale-95 transition-all"
             onClick={scrollToBottom}
           >
-            <ArrowDownIcon className="size-5 md:size-4" />
+            <ArrowDownIcon className="size-5 md:size-4" aria-hidden />
           </button>
         )}
       </div>

--- a/apps/web/src/components/app-loading-placeholder.tsx
+++ b/apps/web/src/components/app-loading-placeholder.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+type AppLoadingPlaceholderProps = {
+	/** Announced to screen readers */
+	message?: string;
+	className?: string;
+	/** Matches authenticated shell: sidebar stub + main pane */
+	variant?: "app-shell" | "simple";
+};
+
+/**
+ * Accessible loading placeholder for route-level and auth-gated suspense states.
+ */
+export function AppLoadingPlaceholder({
+	message = "Loading",
+	className,
+	variant = "simple",
+}: AppLoadingPlaceholderProps) {
+	if (variant === "app-shell") {
+		return (
+			<div
+				className={cn("flex h-screen w-full bg-sidebar", className)}
+				role="status"
+				aria-live="polite"
+				aria-busy="true"
+			>
+				<span className="sr-only">{message}</span>
+				<div className="w-64 shrink-0 bg-sidebar" aria-hidden="true" />
+				<div className="flex-1 bg-background" aria-hidden="true" />
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={cn("flex h-full w-full bg-background", className)}
+			role="status"
+			aria-live="polite"
+			aria-busy="true"
+		>
+			<span className="sr-only">{message}</span>
+		</div>
+	);
+}

--- a/apps/web/src/components/chat/chat-interface.tsx
+++ b/apps/web/src/components/chat/chat-interface.tsx
@@ -51,6 +51,8 @@ export function ChatInterface({ chatId }: ChatInterfaceProps) {
 		error,
 		stop,
 		isNewChat,
+		isLoadingMessages,
+		resetChatError,
 	} = usePersistentChat({
 		chatId,
 		onChatCreated: (newChatId) => {
@@ -92,7 +94,9 @@ export function ChatInterface({ chatId }: ChatInterfaceProps) {
 				messages={messages}
 				isLoading={isLoading}
 				isNewChat={isNewChat}
-				error={error ?? null}
+				isLoadingHistory={Boolean(chatId) && isLoadingMessages}
+				streamError={error ?? null}
+				onDismissStreamError={resetChatError}
 				stop={stop}
 				handleSubmit={handleSubmit}
 				onEditMessage={editMessage}
@@ -114,7 +118,9 @@ interface ChatInterfaceContentProps {
 	}>;
 	isLoading: boolean;
 	isNewChat: boolean;
-	error: Error | null;
+	isLoadingHistory: boolean;
+	streamError: Error | null;
+	onDismissStreamError: () => void;
 	stop: () => void;
 	handleSubmit: (message: PromptInputMessage) => Promise<void>;
 	onEditMessage: (messageId: string, newContent: string) => Promise<void>;
@@ -128,7 +134,9 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 	messages,
 	isLoading,
 	isNewChat,
-	error: _error,
+	isLoadingHistory,
+	streamError,
+	onDismissStreamError,
 	stop,
 	handleSubmit,
 	onEditMessage,
@@ -137,6 +145,8 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 	textareaRef,
 }: ChatInterfaceContentProps) {
 	const controller = usePromptInputController();
+	const promptValueRef = useRef(controller.textInput.value);
+	promptValueRef.current = controller.textInput.value;
 	const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
 	const [isSavingEdit, setIsSavingEdit] = useState(false);
 	const savedDraftRef = useRef<string>("");
@@ -201,14 +211,14 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 
 	const startEdit = useCallback(
 		(messageId: string, content: string) => {
-			savedDraftRef.current = controller.textInput.value;
+			savedDraftRef.current = promptValueRef.current;
 			setEditingMessageId(messageId);
 			setInput(content);
 			setTimeout(() => {
 				textareaRef.current?.focus();
 			}, 0);
 		},
-		[controller.textInput.value, setInput, textareaRef],
+		[setInput, textareaRef],
 	);
 
 	const cancelEdit = useCallback(() => {
@@ -260,6 +270,9 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 				messages={messages}
 				isLoading={isLoading}
 				isNewChat={isNewChat}
+				isLoadingHistory={isLoadingHistory}
+				streamError={streamError}
+				onDismissStreamError={onDismissStreamError}
 				onPromptSelect={onPromptSelect}
 				onRetryMessage={onRetryMessage}
 				onForkMessage={onForkMessage}
@@ -270,11 +283,16 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 			<div className="px-2 md:px-4 pt-2 md:pt-4 pb-[max(0.5rem,env(safe-area-inset-bottom))] md:pb-4">
 				<div className="mx-auto max-w-3xl">
 					{editingMessageId && (
-						<div className="mb-2 flex items-center justify-between rounded-lg bg-primary/10 border border-primary/20 px-3 py-2">
+						<div
+							className="mb-2 flex items-center justify-between rounded-lg bg-primary/10 border border-primary/20 px-3 py-2"
+							role="status"
+							aria-live="polite"
+						>
 							<span className="text-sm text-primary font-medium">Editing message</span>
 							<button
 								type="button"
 								onClick={cancelEdit}
+								aria-label="Cancel editing message"
 								className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 							>
 								<XIcon className="size-3" />

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Loader2Icon, XIcon } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useConversationScroll, Conversation, ConversationContent } from "@/components/ai-elements/conversation";
@@ -36,10 +37,16 @@ function AutoScroll({ messageCount }: { messageCount: number }) {
 
 function LoadingIndicator() {
 	return (
-		<div className="flex items-center gap-1.5 py-2">
-			<span className="size-2 animate-bounce rounded-full bg-foreground/40 [animation-delay:0ms]" />
-			<span className="size-2 animate-bounce rounded-full bg-foreground/40 [animation-delay:150ms]" />
-			<span className="size-2 animate-bounce rounded-full bg-foreground/40 [animation-delay:300ms]" />
+		<div
+			className="flex items-center gap-1.5 py-2"
+			role="status"
+			aria-live="polite"
+			aria-busy="true"
+		>
+			<span className="sr-only">Assistant is responding</span>
+			<span className="size-2 animate-bounce rounded-full bg-foreground/40 [animation-delay:0ms]" aria-hidden />
+			<span className="size-2 animate-bounce rounded-full bg-foreground/40 [animation-delay:150ms]" aria-hidden />
+			<span className="size-2 animate-bounce rounded-full bg-foreground/40 [animation-delay:300ms]" aria-hidden />
 		</div>
 	);
 }
@@ -54,6 +61,10 @@ export interface ChatMessageListProps {
 	}>;
 	isLoading: boolean;
 	isNewChat: boolean;
+	/** True while Convex history for an existing chat is still loading */
+	isLoadingHistory?: boolean;
+	streamError?: Error | null;
+	onDismissStreamError?: () => void;
 	onPromptSelect: (prompt: string) => void;
 	onRetryMessage: (messageId: string, modelId?: string) => Promise<void>;
 	onForkMessage: (messageId: string, modelId?: string) => Promise<void>;
@@ -66,6 +77,9 @@ export const ChatMessageList = memo(function ChatMessageList({
 	messages,
 	isLoading,
 	isNewChat,
+	isLoadingHistory = false,
+	streamError = null,
+	onDismissStreamError,
 	onPromptSelect,
 	onRetryMessage,
 	onForkMessage,
@@ -241,9 +255,44 @@ export const ChatMessageList = memo(function ChatMessageList({
 		<Conversation className="flex-1 px-2 md:px-4" showScrollButton>
 			<AutoScroll messageCount={messages.length} />
 			<ConversationContent className="mx-auto max-w-3xl pt-16 md:pt-6 pb-16 px-2 md:px-4">
-				{messages.length === 0 && isNewChat ? (
+				{streamError && (
+					<div
+						role="alert"
+						className="mb-4 flex gap-3 rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm"
+					>
+						<div className="min-w-0 flex-1">
+							<p className="font-medium text-destructive">Something went wrong</p>
+							<p className="mt-1 text-destructive/80">{streamError.message}</p>
+						</div>
+						{onDismissStreamError ? (
+							<button
+								type="button"
+								onClick={onDismissStreamError}
+								className="shrink-0 rounded-lg p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+								aria-label="Dismiss error"
+							>
+								<XIcon className="size-4" />
+							</button>
+						) : null}
+					</div>
+				)}
+				{isLoadingHistory && messages.length === 0 ? (
+					<div
+						className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground"
+						role="status"
+						aria-live="polite"
+						aria-busy="true"
+					>
+						<Loader2Icon className="size-8 animate-spin" aria-hidden />
+						<span className="sr-only">Loading conversation</span>
+					</div>
+				) : messages.length === 0 && isNewChat ? (
 					<StartScreen onPromptSelect={onPromptSelect} />
-				) : messages.length === 0 ? null : (
+				) : messages.length === 0 ? (
+					<p className="py-12 text-center text-sm text-muted-foreground">
+						No messages in this chat yet. Send a message below to start.
+					</p>
+				) : (
 					<>
 						{processedMessages.map((item, itemIndex) => {
 							if (item.shouldSkip) return null;

--- a/apps/web/src/components/chat/inline-error-message.tsx
+++ b/apps/web/src/components/chat/inline-error-message.tsx
@@ -61,12 +61,13 @@ export function InlineErrorMessage({ error, onRetry }: InlineErrorMessageProps) 
 	return (
 		<div className="w-full rounded-xl border border-destructive/30 bg-destructive/10 p-4">
 			<div className="flex items-start gap-3">
-				<div className="flex-shrink-0 mt-0.5">
+				<div className="flex-shrink-0 mt-0.5" aria-hidden>
 					<svg
 						className="size-5 text-destructive"
 						fill="none"
 						viewBox="0 0 24 24"
 						stroke="currentColor"
+						aria-hidden
 					>
 						<path
 							strokeLinecap="round"
@@ -85,8 +86,10 @@ export function InlineErrorMessage({ error, onRetry }: InlineErrorMessageProps) 
 					{error.details && (
 						<div className="mt-2">
 							<button
+								type="button"
 								onClick={() => setShowDetails(!showDetails)}
 								className="text-xs text-destructive/60 hover:text-destructive transition-colors"
+								aria-expanded={showDetails}
 							>
 								{showDetails ? "Hide details" : "Show details"}
 							</button>

--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -170,10 +170,6 @@ export function ModelSelector({
 					e.preventDefault();
 					handleClose();
 					break;
-				case "Tab":
-					e.preventDefault();
-					handleClose();
-					break;
 			}
 		}
 

--- a/apps/web/src/components/model-selector/model-item.tsx
+++ b/apps/web/src/components/model-selector/model-item.tsx
@@ -71,6 +71,7 @@ export function ModelItem({
 							: "text-muted-foreground/20 hover:text-amber-400 opacity-0 group-hover:opacity-100",
 					)}
 					title={isFavorite ? "Remove from favorites" : "Add to favorites"}
+					aria-label={isFavorite ? `Remove ${model.name} from favorites` : `Add ${model.name} to favorites`}
 				>
 					<StarIcon filled={isFavorite} className="size-4" />
 				</button>
@@ -117,6 +118,7 @@ export function ModelItem({
 						onInfoHover();
 					}}
 					className="flex size-6 items-center justify-center rounded-md text-muted-foreground/40 transition-all duration-150 hover:text-foreground hover:bg-accent/80"
+					aria-label={`Model details for ${model.name}`}
 				>
 					<InfoIcon className="size-3.5" />
 				</button>

--- a/apps/web/src/hooks/__tests__/use-persistent-chat.test.ts
+++ b/apps/web/src/hooks/__tests__/use-persistent-chat.test.ts
@@ -265,6 +265,7 @@ describe("initial state shape", () => {
 		expect(typeof result.current.retryMessage).toBe("function");
 		expect(typeof result.current.forkMessage).toBe("function");
 		expect(typeof result.current.stop).toBe("function");
+		expect(typeof result.current.resetChatError).toBe("function");
 	});
 });
 
@@ -410,6 +411,23 @@ describe("error tracking", () => {
 			await result.current.sendMessage({ text: "Second" });
 		});
 		expect(result.current.error).toBeUndefined();
+	});
+
+	it("resetChatError clears error and returns status from error to ready", async () => {
+		mockStartBackgroundStream.mockRejectedValueOnce(new Error("boom"));
+
+		const { result } = renderChat();
+		await act(async () => {
+			await result.current.sendMessage({ text: "Hello" });
+		});
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toBeTruthy();
+
+		await act(async () => {
+			result.current.resetChatError();
+		});
+		expect(result.current.error).toBeUndefined();
+		expect(result.current.status).toBe("ready");
 	});
 });
 

--- a/apps/web/src/hooks/use-persistent-chat.ts
+++ b/apps/web/src/hooks/use-persistent-chat.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
 import type { UIMessage } from "ai";
@@ -30,6 +30,8 @@ export interface UsePersistentChatReturn {
 	chatId: string | null;
 	isResuming: boolean;
 	resumedContent: string;
+	/** Clears the last stream/send error and returns status from `error` to `ready` when applicable */
+	resetChatError: () => void;
 }
 
 export function usePersistentChat({
@@ -84,6 +86,11 @@ export function usePersistentChat({
 		streamingRef,
 	});
 
+	const resetChatError = useCallback(() => {
+		setError(undefined);
+		setStatus((prev) => (prev === "error" ? "ready" : prev));
+	}, []);
+
 	const { sendMessage, editMessage, retryMessage, forkMessage } = useChatActions({
 		convexUserId,
 		isUserLoading,
@@ -117,5 +124,6 @@ export function usePersistentChat({
 		chatId: currentChatId,
 		isResuming,
 		resumedContent,
+		resetChatError,
 	};
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -17,6 +17,7 @@ import { usePostHogPageView } from "../providers/posthog";
 import { convexClient } from "../lib/convex";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { ShortcutsDialog } from "@/components/shortcuts-dialog";
+import { AppLoadingPlaceholder } from "@/components/app-loading-placeholder";
 import type { InitialAuthUser } from "../lib/auth-client";
 
 import appCss from "../styles.css?url";
@@ -193,12 +194,7 @@ function AppShell() {
   const showHelpButton = isAuthenticated && (pathname === "/" || pathname.startsWith("/c/"));
 
   if (!convexClient || loading) {
-    return (
-      <div className="flex h-screen w-full bg-sidebar">
-        <div className="w-64 shrink-0 bg-sidebar" />
-        <div className="flex-1 bg-background" />
-      </div>
-    );
+    return <AppLoadingPlaceholder variant="app-shell" message="Loading application" />;
   }
 
   if (!isAuthenticated) {

--- a/apps/web/src/routes/c/$chatId.tsx
+++ b/apps/web/src/routes/c/$chatId.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@/lib/auth-client";
 import { ChatInterface } from "@/components/chat";
 import { Button } from "@/components/ui/button";
 import { convexClient } from "@/lib/convex";
+import { AppLoadingPlaceholder } from "@/components/app-loading-placeholder";
 
 export const Route = createFileRoute("/c/$chatId")({
   head: () => ({
@@ -27,7 +28,7 @@ function ChatPage() {
   const { isAuthenticated, loading } = useAuth();
 
   if (!convexClient || loading) {
-    return <div className="flex h-full bg-background" />;
+    return <AppLoadingPlaceholder message="Loading" />;
   }
 
   if (!isAuthenticated) {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../lib/auth-client";
 import { Button } from "../components/ui/button";
 import { ChatInterface } from "../components/chat";
 import { convexClient } from "../lib/convex";
+import { AppLoadingPlaceholder } from "../components/app-loading-placeholder";
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -104,6 +105,7 @@ function InteractiveStaircase({
       className={`${className} relative`}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
+      aria-hidden
     >
       {squares.map(({ col, row, key }) => {
         const rightPos = (gridSize - 1 - col) * stepSize
@@ -241,7 +243,7 @@ function HomePage() {
   }, [isAuthenticated]);
 
   if (!convexClient || loading) {
-    return <div className="flex h-full bg-background" />;
+    return <AppLoadingPlaceholder message="Loading" />;
   }
 
   if (!isAuthenticated) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Delivers fixes from a focused frontend audit of `apps/web` (architecture touchpoints, UX gaps, accessibility).

## Findings addressed
- **Architecture:** `ChatInterfaceContent`’s `startEdit` depended on `controller.textInput.value`, recreating the callback on every keystroke and weakening memoization. Draft is now captured via a ref updated each render.
- **UX:** Top-level `error` from `usePersistentChat` was never shown (only persisted inline error messages). Route-level loading used silent empty panes. Existing chats with no messages yet rendered a blank column.
- **Accessibility:** Model dropdown intercepted **Tab** globally with `preventDefault`, blocking normal tab order. Scroll-to-latest control was icon-only. Model row favorite/info buttons lacked accessible names. Loading and assistant “typing” affordances were visual-only.

## Changes
- `AppLoadingPlaceholder` + wired into `__root`, `/`, `/c/$chatId` with `role="status"`, `aria-busy`, and screen-reader text.
- `resetChatError()` on `usePersistentChat` clears error and returns `status` from `error` → `ready`; dismissible `role="alert"` banner in `ChatMessageList`.
- History loading state (spinner + SR text) when `isLoadingMessages` and messages are empty.
- Empty-state copy for non–new-chat with zero messages.
- `Conversation`: `aria-label="Chat messages"`; scroll button `aria-label` + decorative icon hidden.
- `ModelSelector`: removed Tab handler that trapped focus.
- `ModelItem`: `aria-label` on favorite and info actions.
- `InlineErrorMessage`: `aria-hidden` on decorative SVG wrapper; details toggle `type="button"` + `aria-expanded`.
- Landing `InteractiveStaircase`: `aria-hidden` (purely decorative).

## Testing
- `cd apps/web && bun run test -- src/hooks/__tests__/use-persistent-chat.test.ts src/components/__tests__/chat-interface.test.tsx src/components/model-selector/__tests__/model-item.test.tsx src/components/chat/__tests__/inline-error-message.test.tsx`

## Notes
Broader refactors (e.g. splitting `ChatMessageList` message row into a memoized child, design-token pass for contrast) were out of scope for this PR; happy to follow up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d84653a1-506f-49df-8a1c-e3d22e528eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d84653a1-506f-49df-8a1c-e3d22e528eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve accessibility, loading UX, and chat error handling in the frontend
> - Adds a reusable `AppLoadingPlaceholder` component with `app-shell` and `simple` variants, replacing bare loading containers in the root, chat, and home routes with accessible skeletons (`role=status`, `aria-live`, `aria-busy`).
> - Adds `resetChatError` to `usePersistentChat`, exposing a way to clear stream errors and return status to `ready`; surfaces this in `ChatInterface` and `ChatMessageList` as a dismissible error alert.
> - `ChatMessageList` gains a loading state for existing chat history and a zero-state message for empty non-new chats.
> - Adds `aria-label` attributes throughout `Conversation`, `ModelItem`, and `InlineErrorMessage`; marks decorative icons as `aria-hidden`; adds `role=status` to the chat loading indicator.
> - Fixes `Tab` key in `ModelSelector` to use default browser focus behavior instead of forcibly closing the dropdown.
> - Fixes a stale closure in `ChatInterfaceContent.startEdit` by reading prompt value from a ref.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c77b396.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->