### PR TITLE
Backend code quality: Convex query efficiency, Redis TTLs, safer types

### DIFF
--- a/apps/server/convex/__tests__/backgroundStream.test.ts
+++ b/apps/server/convex/__tests__/backgroundStream.test.ts
@@ -299,9 +299,9 @@ describe("backgroundStream", () => {
 
 		// A new message should have been created
 		const message = await t.run(async (ctx) => {
-			return await (ctx.db as any)
+			return await ctx.db
 				.query("messages")
-				.withIndex("by_client_id", (q: any) =>
+				.withIndex("by_client_id", (q) =>
 					q.eq("chatId", chatId).eq("clientMessageId", "msg-008"),
 				)
 				.first();
@@ -353,9 +353,9 @@ describe("backgroundStream", () => {
 
 		// Only one message should exist for this clientMessageId
 		const allMessages = await t.run(async (ctx) => {
-			return await (ctx.db as any)
+			return await ctx.db
 				.query("messages")
-				.withIndex("by_client_id", (q: any) =>
+				.withIndex("by_client_id", (q) =>
 					q.eq("chatId", chatId).eq("clientMessageId", "msg-009"),
 				)
 				.collect();

--- a/apps/server/convex/chatFork.ts
+++ b/apps/server/convex/chatFork.ts
@@ -1,4 +1,5 @@
-import { mutation } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, type MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { incrementStat, STAT_KEYS } from "./lib/dbStats";
 import { rateLimiter } from "./lib/rateLimiter";
@@ -7,6 +8,48 @@ import { requireAuthUserId } from "./lib/auth";
 import { assertOwnsChat } from "./chats";
 
 const MAX_FORK_MESSAGE_COPY = 200;
+const FORK_PAGE_SIZE = 200;
+
+function matchesForkPoint(message: Doc<"messages">, messageId: string): boolean {
+	return String(message._id) === messageId || message.clientMessageId === messageId;
+}
+
+/**
+ * Loads messages from the start of the chat in ascending order until the fork
+ * point is reached. Avoids scanning the entire chat when the fork is early.
+ */
+async function collectMessagesThroughFork(
+	ctx: MutationCtx,
+	chatId: Id<"chats">,
+	messageId: string,
+): Promise<Doc<"messages">[]> {
+	const collected: Doc<"messages">[] = [];
+	let cursor: string | null = null;
+
+	while (true) {
+		const page = await ctx.db
+			.query("messages")
+			.withIndex("by_chat_not_deleted", (q) =>
+				q.eq("chatId", chatId).eq("deletedAt", undefined),
+			)
+			.order("asc")
+			.paginate({ cursor, numItems: FORK_PAGE_SIZE });
+
+		for (const message of page.page) {
+			collected.push(message);
+			if (matchesForkPoint(message, messageId)) {
+				return collected;
+			}
+		}
+
+		if (page.isDone) {
+			break;
+		}
+		cursor = page.continueCursor;
+	}
+
+	throw new Error("Fork point message not found");
+}
 
 export const fork = mutation({
 	args: {
@@ -32,26 +75,13 @@ export const fork = mutation({
 			throwRateLimitError("messages forked", retryAfter);
 		}
 
-		const allMessages = await ctx.db
-			.query("messages")
-			.withIndex("by_chat_not_deleted", (q) =>
-				q.eq("chatId", args.chatId).eq("deletedAt", undefined)
-			)
-			.order("asc")
-			.collect();
-
-		const forkIndex = allMessages.findIndex(
-			(message) =>
-				String(message._id) === args.messageId ||
-				message.clientMessageId === args.messageId,
+		const prefixThroughFork = await collectMessagesThroughFork(
+			ctx,
+			args.chatId,
+			args.messageId,
 		);
-		if (forkIndex === -1) {
-			throw new Error("Fork point message not found");
-		}
 
-		const messagesToCopy = allMessages
-			.slice(0, forkIndex + 1)
-			.slice(-MAX_FORK_MESSAGE_COPY);
+		const messagesToCopy = prefixThroughFork.slice(-MAX_FORK_MESSAGE_COPY);
 
 		const now = Date.now();
 		const newChatId = await ctx.db.insert("chats", {

--- a/apps/server/convex/chatShares.ts
+++ b/apps/server/convex/chatShares.ts
@@ -68,12 +68,13 @@ async function getActiveShareForChat(
 	userId: Id<"users">,
 	chatId: Id<"chats">,
 ) {
-	const shares = await ctx.db
+	return await ctx.db
 		.query("chatShares")
-		.withIndex("by_user_chat_revoked_updated", (q) => q.eq("userId", userId).eq("chatId", chatId))
+		.withIndex("by_user_chat_revoked_updated", (q) =>
+			q.eq("userId", userId).eq("chatId", chatId).eq("revokedAt", undefined),
+		)
 		.order("desc")
-		.collect();
-	return shares.find((share) => !share.revokedAt) ?? null;
+		.first();
 }
 
 function normalizePreviewText(text: string) {

--- a/apps/server/convex/files.ts
+++ b/apps/server/convex/files.ts
@@ -413,8 +413,11 @@ export const getUserQuota = query({
 	},
 });
 
+/** Cap for list queries to avoid unbounded reads on accounts with many uploads. */
+const MAX_FILES_LIST = 2000;
+
 /**
- * Retrieves all non-deleted files for a specific chat.
+ * Retrieves non-deleted files for a specific chat (most recent first, capped).
  *
  * @param chatId - The ID of the chat
  * @param userId - The ID of the user (for authorization)
@@ -440,21 +443,20 @@ export const getFilesByChat = query({
 		const userId = await requireAuthUserId(ctx, args.userId);
 		await getOwnedChat(ctx, args.chatId, userId);
 
-		// Query all non-deleted files for this chat
 		const files = await ctx.db
 			.query("fileUploads")
 			.withIndex("by_chat_not_deleted", (q) =>
 				q.eq("chatId", args.chatId).eq("deletedAt", undefined)
 			)
 			.order("desc")
-			.collect();
+			.take(MAX_FILES_LIST);
 
 		return files.map(toFileSummary);
 	},
 });
 
 /**
- * Retrieves all non-deleted files for a specific user.
+ * Retrieves non-deleted files for a specific user (most recent first, capped).
  *
  * @param userId - The ID of the user
  * @returns Array of file metadata objects with chat information
@@ -477,14 +479,13 @@ export const getFilesByUser = query({
 	),
 	handler: async (ctx, args) => {
 		const userId = await requireAuthUserId(ctx, args.userId);
-		// Query all non-deleted files for this user
 		const files = await ctx.db
 			.query("fileUploads")
 			.withIndex("by_user_not_deleted", (q) =>
 				q.eq("userId", userId).eq("deletedAt", undefined)
 			)
 			.order("desc")
-			.collect();
+			.take(MAX_FILES_LIST);
 
 		return files.map((file) => ({
 			...toFileSummary(file),

--- a/apps/server/convex/message_helpers.ts
+++ b/apps/server/convex/message_helpers.ts
@@ -34,30 +34,32 @@ async function validateAttachmentOwnership(
 		);
 	}
 
-	for (const attachment of attachments) {
-		const fileUpload = await ctx.db
-			.query("fileUploads")
-			.withIndex("by_storage", (q) => q.eq("storageId", attachment.storageId))
-			.unique();
+	await Promise.all(
+		attachments.map(async (attachment) => {
+			const fileUpload = await ctx.db
+				.query("fileUploads")
+				.withIndex("by_storage", (q) => q.eq("storageId", attachment.storageId))
+				.unique();
 
-		if (!fileUpload) {
-			throw new Error(
-				"Unauthorized: attachment references a file that does not exist in your uploads.",
-			);
-		}
+			if (!fileUpload) {
+				throw new Error(
+					"Unauthorized: attachment references a file that does not exist in your uploads.",
+				);
+			}
 
-		if (fileUpload.userId !== userId) {
-			throw new Error(
-				"Unauthorized: you do not own the referenced attachment file.",
-			);
-		}
+			if (fileUpload.userId !== userId) {
+				throw new Error(
+					"Unauthorized: you do not own the referenced attachment file.",
+				);
+			}
 
-		if (fileUpload.deletedAt) {
-			throw new Error(
-				"Attachment references a file that has been deleted.",
-			);
-		}
-	}
+			if (fileUpload.deletedAt) {
+				throw new Error(
+					"Attachment references a file that has been deleted.",
+				);
+			}
+		}),
+	);
 }
 
 export async function getVerifiedStorageIds(

--- a/apps/server/convex/message_queries.ts
+++ b/apps/server/convex/message_queries.ts
@@ -120,10 +120,9 @@ export const getFirstUserMessage = query({
 
 		const message = await ctx.db
 			.query("messages")
-			.withIndex("by_chat_not_deleted", (q) =>
-				q.eq("chatId", args.chatId).eq("deletedAt", undefined)
+			.withIndex("by_chat_not_deleted_role", (q) =>
+				q.eq("chatId", args.chatId).eq("deletedAt", undefined).eq("role", "user"),
 			)
-			.filter((q) => q.eq(q.field("role"), "user"))
 			.order("asc")
 			.first();
 

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -180,6 +180,7 @@ export default defineSchema({
 		.index("by_user", ["userId"])
 		.index("by_user_status", ["userId", "status", "createdAt"])
 		.index("by_chat_not_deleted", ["chatId", "deletedAt", "createdAt"])
+		.index("by_chat_not_deleted_role", ["chatId", "deletedAt", "role", "createdAt"])
 		.index("by_user_created", ["userId", "createdAt"])
 		.index("by_stream_id", ["streamId"])
 		.index("by_chat_status", ["chatId", "status", "deletedAt"]),

--- a/apps/web/src/lib/redis.ts
+++ b/apps/web/src/lib/redis.ts
@@ -4,6 +4,8 @@ const STREAM_TTL_SECONDS = 3600;
 const STREAM_ERROR_TTL_SECONDS = 600;
 const TYPING_TTL_SECONDS = 3;
 const PRESENCE_TTL_SECONDS = 60;
+/** Per-user unread hash: refresh on write/read so inactive users do not retain keys forever. */
+const UNREAD_HASH_TTL_SECONDS = 60 * 60 * 24 * 90;
 const ONLINE_WINDOW_MS = 60_000;
 
 const keys = {
@@ -290,23 +292,31 @@ export async function isUserOnline(userId: string): Promise<boolean> {
 export async function incrementUnread(userId: string, chatId: string): Promise<void> {
 	const client = await getConnectedClient();
 	if (!client) return;
-	await client.hincrby(keys.unread(userId), chatId, 1);
+	const key = keys.unread(userId);
+	await client.hincrby(key, chatId, 1);
+	await client.expire(key, UNREAD_HASH_TTL_SECONDS);
 }
 
 export async function clearUnread(userId: string, chatId: string): Promise<void> {
 	const client = await getConnectedClient();
 	if (!client) return;
-	await client.hdel(keys.unread(userId), chatId);
+	const key = keys.unread(userId);
+	await client.hdel(key, chatId);
+	await client.expire(key, UNREAD_HASH_TTL_SECONDS);
 }
 
 export async function getUnreadCounts(userId: string): Promise<Record<string, number>> {
 	const client = await getConnectedClient();
 	if (!client) return {};
 
-	const counts = await client.hgetall<Record<string, string>>(keys.unread(userId));
+	const key = keys.unread(userId);
+	const counts = await client.hgetall<Record<string, string>>(key);
 	const result: Record<string, number> = {};
 	for (const [chatId, count] of Object.entries(counts ?? {})) {
 		result[chatId] = Number.parseInt(count, 10);
+	}
+	if (Object.keys(result).length > 0) {
+		await client.expire(key, UNREAD_HASH_TTL_SECONDS);
 	}
 	return result;
 }

--- a/apps/web/src/lib/upstash.ts
+++ b/apps/web/src/lib/upstash.ts
@@ -268,6 +268,11 @@ function createSlidingWindowRatelimit(
 		return {
 			limit: async (identifier: string) => {
 				const now = Date.now();
+				for (const [key, entry] of memoryRatelimitStore) {
+					if (entry.resetAt <= now) {
+						memoryRatelimitStore.delete(key);
+					}
+				}
 				const key = `${prefix}:${identifier}`;
 				const existing = memoryRatelimitStore.get(key);
 				if (!existing || existing.resetAt <= now) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up from a backend / code quality pass focused on Convex read patterns, Redis key lifecycle, TypeScript noise in tests, and small parallelization wins.

## Analysis (what we found)

### API / Convex efficiency
- **chatShares**: `getActiveShareForChat` loaded every share row for `(userId, chatId)` then scanned for a non-revoked row. Now uses the existing composite index with `revokedAt = undefined` and `.first()`.
- **getFirstUserMessage**: Used `.filter` on role after `by_chat_not_deleted`. Added **`by_chat_not_deleted_role`** and an index-only query path.
- **chatFork**: Loaded the full message list with `.collect()` even when the fork point was early. Now **paginates** in order until the fork message is found (same worst case, much better typical case for long chats).
- **getFilesByChat / getFilesByUser**: Unbounded `.collect()`. Now **capped at 2000** rows (most recent first) to bound read cost.
- **validateAttachmentOwnership**: Sequential indexed lookups per attachment; now **parallelized** with `Promise.all` (same semantics, lower latency).
- **Not changed in this PR**: `messages.list` still loads the full chat for the authenticated UI path. Proper cursor-based pagination would be a separate API + client change.

### Redis
- **Models cache** (`api/models`): Already uses a 4h TTL — no change.
- **Stream / meta / typing / presence**: Already set TTLs on write — no change.
- **Unread counts**: `HINCRBY` on `user:{id}:unread` had **no expiry**, so hashes could live forever. Now the hash gets a **90-day TTL**, refreshed on increment, clear, and read.
- **Dev in-memory rate limit** (`upstash.ts`): Map could grow with many identifiers; now **expired window entries are pruned** on each `limit()` call.

### TypeScript
- Removed unnecessary `(ctx.db as any)` / `(q: any)` usage in `backgroundStream.test.ts` (convex-test `ctx` is already typed).

### General
- Tool / chain-of-thought `v.any()` in schema remains intentional for arbitrary provider tool payloads.

## Deploy notes

- New Convex index: **`messages.by_chat_not_deleted_role`**. Deploy / `convex dev` will backfill per Convex’s normal index build.

## Verification

- `bun run test` (full Vitest) — pass
- `bun check` — pass (existing warnings elsewhere unchanged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91338563-d268-4bff-a9e2-495093e13a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91338563-d268-4bff-a9e2-495093e13a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve Convex query efficiency, add Redis TTLs, and use safer types in backend
> - Refactors `fork` in [chatFork.ts](https://github.com/opencoredev/openchat/pull/704/files#diff-5f57423bd21df8399067199d3b331f12730f9000ca6cec6f1e8ef925b2c00458) to use a paginated loader (`collectMessagesThroughFork`) instead of fetching all messages then slicing, avoiding unbounded memory use.
> - Adds a `by_chat_not_deleted_role` index to messages in [schema.ts](https://github.com/opencoredev/openchat/pull/704/files#diff-41c372f0c2929b012891fdccf557b1e350e5ad73ed4e7f1de8368e41841a8e1d) and updates `getFirstUserMessage` to filter by role at the index level instead of in memory.
> - Caps file list queries at 2000 results in [files.ts](https://github.com/opencoredev/openchat/pull/704/files#diff-3b4744d0dd4de0f1e68dc0cf992858767a09eb8cab18d50b24e3b9d443355884) using `.take()` instead of `.collect()`.
> - Adds 90-day TTLs to per-user unread hash keys in [redis.ts](https://github.com/opencoredev/openchat/pull/704/files#diff-71cbe89f9bdb6de839c06b01973d924f1cfd1faa013c836f3991c53e655c7806), refreshed on read, write, and clear, so inactive users' keys eventually expire.
> - Removes `any` casts in [backgroundStream.test.ts](https://github.com/opencoredev/openchat/pull/704/files#diff-a8ca912b16b5e90f6c917b6b00ace376d26e922c11d882a6e4535e9d070e287c) and parallelizes attachment ownership checks in [message_helpers.ts](https://github.com/opencoredev/openchat/pull/704/files#diff-d79d0ce90ea6952b9691e938d905b81b003cbd74ca4a33e74858a8dbdfb43c3f).
> - Behavioral Change: `getFilesByChat` and `getFilesByUser` now return at most 2000 files; previously they returned all matching records.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a13340.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->