### PR TITLE
docs: add Coding Standards & Banned Patterns to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,42 @@ openchat/
 - Assume dev servers are already running; do not start `bun dev*` unless explicitly requested.
 - Prefer build/typecheck/test verification when runtime validation is needed.
 
+## Coding Standards & Banned Patterns
+
+These rules apply to all AI agents and human contributors working in this repository.
+
+### Choose Your Bug — Why We Ban useEffect Misuse
+
+Misusing `useEffect` doesn't help you avoid bugs — it just lets you choose which bug you get. Every effect that syncs state, fetches data, or reacts to user actions is a latent race condition, stale closure, or infinite loop waiting to happen. The rules below eliminate this entire class of bugs.
+
+### Rules
+
+**Rule 1 — BAN direct use of `useEffect`**
+
+Do not use `useEffect` directly. Use `useMountEffect()` only for rare, justified external side-effect syncs (e.g. third-party SDK initialization). Any other use must be approved and documented with a comment explaining why no alternative works.
+
+**Rule 2 — BAN `as any` casts**
+
+Do not use TypeScript `as any` casts. Use proper types, generics, or type guards. If you cannot type something, use `unknown` and narrow it explicitly. `as any` silences the compiler and hides real bugs.
+
+**Rule 3 — Derive state inline, never sync it with effects**
+
+Do not use `useEffect` + `useState` to sync or transform other state. Derive computed values inline during render, or use `useMemo` if the computation is expensive. Effect-based state sync always has at least one render where the derived state is stale.
+
+**Rule 4 — Use data-fetching libraries instead of fetch-in-effect**
+
+Do not fetch data inside `useEffect`. Use `useQuery` (TanStack Query) or an equivalent data-fetching library. These libraries handle caching, deduplication, background refetching, loading states, and error states correctly. Effect-based fetching is a manual reimplementation of these features, done worse.
+
+**Rule 5 — Use event handlers for user actions, not effect flags**
+
+Do not use `useEffect` to react to user interactions by watching a flag or state change. Put the logic directly in the event handler. Effects that watch for 'action triggers' fire one render late and make code impossible to follow.
+
+**Rule 6 — Reset components with keys, not dependency choreography**
+
+Do not use complex `useEffect` dependency arrays to reset or reinitialize component state when an ID or key prop changes. Instead, pass the relevant value as the `key` prop to the component — React will fully remount it, resetting all state cleanly with zero effect logic.
+
 ## ANTI-PATTERNS (THIS PROJECT)
+- Follow **Coding Standards & Banned Patterns** above for enforced React and TypeScript rules (`useEffect` misuse, `as any`, and related patterns).
 - Do not use `NEXT_PUBLIC_*` env vars in web code.
 - Do not treat `docs-site/` like a regular workspace; it is a git subtree.
 - Do not introduce new logic against deprecated message fields when `chainOfThoughtParts` exists.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a prominent **Coding Standards & Banned Patterns** section to the root `AGENTS.md` for all AI agents and contributors.

## Contents

- **Choose Your Bug** framing: why `useEffect` misuse trades one class of bugs for another
- **Rules 1–6**: ban direct `useEffect` (use `useMountEffect()` only where justified), ban `as any`, derive state without effect sync, use data-fetching libraries instead of fetch-in-effect, use event handlers instead of effect-driven “action flags”, reset via `key` instead of dependency choreography
- Cross-reference from **ANTI-PATTERNS (THIS PROJECT)** so the standards are discoverable from the existing policy list

## Notes

- Rule 4 references TanStack Query `useQuery`; Convex and other vetted `useQuery`-style APIs remain valid under “equivalent data-fetching library” as used elsewhere in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a8dcd3-97da-4566-9e0d-193fe06eb62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a8dcd3-97da-4566-9e0d-193fe06eb62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Coding Standards & Banned Patterns section to AGENTS.md
> Adds a new `Coding Standards & Banned Patterns` section to [AGENTS.md](https://github.com/opencoredev/openchat/pull/706/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) with six explicit rules for AI agents and contributors working in this codebase.
>
> - Bans direct `useEffect` in favor of `useMountEffect` for rare external side-effects with required justification
> - Bans `as any` TypeScript casts in favor of proper typing or `unknown` with narrowing
> - Requires deriving state inline or via `useMemo` rather than syncing with effects
> - Requires data-fetching libraries (e.g., `useQuery`) instead of fetch-in-effect patterns
> - Requires user actions to be handled in event handlers, not effect-driven flags; component resets should use React keys
> - Updates the existing `ANTI-PATTERNS` section to reference and enforce these new standards
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45dc8ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->