### PR TITLE
AGENTS.md compliance: ban direct useEffect, tighten effects and types

### DIFF
--- a/apps/server/convex/__tests__/backgroundStream.test.ts
+++ b/apps/server/convex/__tests__/backgroundStream.test.ts
@@ -299,9 +299,9 @@ describe("backgroundStream", () => {
 
 		// A new message should have been created
 		const message = await t.run(async (ctx) => {
-			return await (ctx.db as any)
+			return await ctx.db
 				.query("messages")
-				.withIndex("by_client_id", (q: any) =>
+				.withIndex("by_client_id", (q) =>
 					q.eq("chatId", chatId).eq("clientMessageId", "msg-008"),
 				)
 				.first();
@@ -353,9 +353,9 @@ describe("backgroundStream", () => {
 
 		// Only one message should exist for this clientMessageId
 		const allMessages = await t.run(async (ctx) => {
-			return await (ctx.db as any)
+			return await ctx.db
 				.query("messages")
-				.withIndex("by_client_id", (q: any) =>
+				.withIndex("by_client_id", (q) =>
 					q.eq("chatId", chatId).eq("clientMessageId", "msg-009"),
 				)
 				.collect();

--- a/apps/web/src/components/ai-elements/__tests__/prompt-input-context.test.tsx
+++ b/apps/web/src/components/ai-elements/__tests__/prompt-input-context.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, act } from "@testing-library/react";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import {
 	LocalAttachmentsContext,
 	PromptInputProvider,
@@ -391,7 +392,7 @@ describe("PromptInputProvider attachments", () => {
 		function Registrar() {
 			const ctx = usePromptInputController();
 			const ref = useRef<HTMLInputElement | null>(null);
-			useEffect(() => {
+			useEffectOnDeps(() => {
 				ctx.__registerFileInput(ref, openFn);
 			}, [ctx]);
 			return null;

--- a/apps/web/src/components/ai-elements/code-block.tsx
+++ b/apps/web/src/components/ai-elements/code-block.tsx
@@ -7,7 +7,6 @@ import {
   memo,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -21,6 +20,7 @@ import type {
 } from 'shiki'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { useEffectOnDeps, useMountEffect } from '@/hooks/use-mount-effect'
 
 type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
   code: string
@@ -212,7 +212,7 @@ const CodeBlockContent = ({
   const rawTokens = useMemo(() => createRawTokens(code), [code])
   const [tokenized, setTokenized] = useState<TokenizedCode>(rawTokens)
 
-  useEffect(() => {
+  useEffectOnDeps(() => {
     let cancelled = false
     setTokenized(rawTokens)
 
@@ -362,11 +362,10 @@ export const CodeBlockCopyButton = ({
     }
   }, [code, isCopied, onCopy, onError, timeout])
 
-  useEffect(
+  useMountEffect(
     () => () => {
       window.clearTimeout(timeoutRef.current)
     },
-    [],
   )
 
   const Icon = isCopied ? CheckIcon : CopyIcon

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -11,7 +11,8 @@
  */
 
 import { ArrowDownIcon } from "lucide-react";
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import type { ComponentProps, RefObject } from "react";
 import { cn } from "@/lib/utils";
 
@@ -58,7 +59,7 @@ export const Conversation = ({ className, children, showScrollButton = false, ..
   }, []);
 
   // Track scroll position
-  useEffect(() => {
+  useMountEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
 
@@ -72,7 +73,7 @@ export const Conversation = ({ className, children, showScrollButton = false, ..
     handleScroll(); // Check initial state
 
     return () => el.removeEventListener("scroll", handleScroll);
-  }, []);
+  });
 
   return (
     <ConversationContext.Provider value={{ scrollRef, isAtBottom, scrollToBottom }}>

--- a/apps/web/src/components/ai-elements/prompt-input-context.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input-context.tsx
@@ -3,13 +3,13 @@ import {
 	createContext,
 	useCallback,
 	useContext,
-	useEffect,
 	useMemo,
 	useRef,
 	useState,
 } from "react";
 import type { FileUIPart } from "ai";
 import type { PropsWithChildren, RefObject } from "react";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 
 // ============================================================================
 // Provider Context & Types
@@ -149,7 +149,7 @@ export function PromptInputProvider({
 	attachmentsRef.current = attachmentFiles;
 
 	// Cleanup blob URLs on unmount to prevent memory leaks
-	useEffect(() => {
+	useMountEffect(() => {
 		return () => {
 			for (const f of attachmentsRef.current) {
 				if (f.url) {
@@ -157,7 +157,7 @@ export function PromptInputProvider({
 				}
 			}
 		};
-	}, []);
+	});
 
 	const openFileDialog = useCallback(() => {
 		openRef.current();

--- a/apps/web/src/components/ai-elements/prompt-input-speech.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input-speech.tsx
@@ -1,5 +1,6 @@
 import { MicIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import type { ComponentProps, RefObject } from "react";
 import { cn } from "@/lib/utils";
 import { PromptInputButton } from "./prompt-input-primitives";
@@ -69,7 +70,7 @@ export const PromptInputSpeechButton = ({
 	const [recognition, setRecognition] = useState<SpeechRecognition | null>(null);
 	const recognitionRef = useRef<SpeechRecognition | null>(null);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (typeof window === "undefined") return;
 
 		const SpeechRecognitionClass = window.SpeechRecognition ?? window.webkitSpeechRecognition;

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import type { FileUIPart } from "ai";
 import type { ChangeEventHandler, FormEvent, FormEventHandler, HTMLAttributes } from "react";
 import { InputGroup } from "@/components/ui/input-group";
@@ -170,18 +171,18 @@ export const PromptInput = ({
 		? controller.attachments.openFileDialog
 		: openFileDialogLocal;
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!usingProvider) return;
 		controller.__registerFileInput(inputRef, () => inputRef.current?.click());
 	}, [usingProvider, controller]);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (syncHiddenInput && inputRef.current && files.length === 0) {
 			inputRef.current.value = "";
 		}
 	}, [files, syncHiddenInput]);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		const form = formRef.current;
 		if (!form) return;
 		if (globalDrop) return;
@@ -207,7 +208,7 @@ export const PromptInput = ({
 		};
 	}, [add, globalDrop]);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!globalDrop) return;
 
 		const onDragOver = (e: DragEvent) => {
@@ -231,7 +232,7 @@ export const PromptInput = ({
 		};
 	}, [add, globalDrop]);
 
-	useEffect(
+	useEffectOnDeps(
 		() => () => {
 			if (!usingProvider) {
 				for (const f of filesRef.current) {

--- a/apps/web/src/components/ai-elements/reasoning.tsx
+++ b/apps/web/src/components/ai-elements/reasoning.tsx
@@ -2,7 +2,8 @@
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
-import { createContext, memo, useContext, useEffect, useState } from "react";
+import { createContext, memo, useContext, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { Streamdown } from "streamdown";
 import { Shimmer } from "./shimmer";
 import type { ComponentProps, ReactNode } from "react";
@@ -63,7 +64,7 @@ export const Reasoning = memo(
 
 		const [startTime, setStartTime] = useState<number | null>(null);
 
-		useEffect(() => {
+		useEffectOnDeps(() => {
 			if (isStreaming) {
 				if (startTime === null) {
 					setStartTime(Date.now());

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
@@ -63,19 +64,19 @@ export function AppSidebar({
 
 	const cachedChatsRef = useRef<Array<ChatItem> | null>(null);
 
-	useEffect(() => {
+	useMountEffect(() => {
 		if (typeof window === "undefined") return;
 		try {
 			const stored = sessionStorage.getItem(CHATS_CACHE_KEY);
 			if (stored && !cachedChatsRef.current) {
-				cachedChatsRef.current = JSON.parse(stored);
+				cachedChatsRef.current = JSON.parse(stored) as Array<ChatItem>;
 			}
 		} catch (e) {
 			console.warn("Failed to load chats from sessionStorage:", e);
 		}
-	}, []);
+	});
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (chatsResult?.chats && chatsResult.chats.length > 0) {
 			cachedChatsRef.current = chatsResult.chats;
 			try {

--- a/apps/web/src/components/chat/chat-interface.tsx
+++ b/apps/web/src/components/chat/chat-interface.tsx
@@ -10,7 +10,8 @@
  * - Convex persistence for chat history
  */
 
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import { useNavigate } from "@tanstack/react-router";
 import { XIcon } from "lucide-react";
 import { PromptInputProvider, usePromptInputController } from "@/components/ai-elements/prompt-input";
@@ -88,6 +89,7 @@ export function ChatInterface({ chatId }: ChatInterfaceProps) {
 	return (
 		<PromptInputProvider>
 			<ChatInterfaceContent
+				key={chatId ?? "__new__"}
 				chatId={chatId ?? null}
 				messages={messages}
 				isLoading={isLoading}
@@ -148,12 +150,12 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 		textInputController: controller.textInput,
 	});
 
-	useEffect(() => {
-		setEditingMessageId(null);
-		setIsSavingEdit(false);
-	}, [chatId]);
+	const isLoadingRef = useRef(isLoading);
+	isLoadingRef.current = isLoading;
+	const stopRef = useRef(stop);
+	stopRef.current = stop;
 
-	useEffect(() => {
+	useMountEffect(() => {
 		const onFocusPromptToggle = () => {
 			const textarea = textareaRef.current;
 			if (!textarea) return;
@@ -175,8 +177,8 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 		};
 
 		const onStopGeneration = () => {
-			if (!isLoading) return;
-			stop();
+			if (!isLoadingRef.current) return;
+			stopRef.current();
 		};
 
 		window.addEventListener(SHORTCUT_EVENT_FOCUS_PROMPT_TOGGLE, onFocusPromptToggle);
@@ -186,7 +188,7 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 			window.removeEventListener(SHORTCUT_EVENT_FOCUS_PROMPT_TOGGLE, onFocusPromptToggle);
 			window.removeEventListener(SHORTCUT_EVENT_STOP_GENERATION, onStopGeneration);
 		};
-	}, [isLoading, stop, textareaRef]);
+	});
 
 	const setInput = controller.textInput.setInput;
 	const onPromptSelect = useCallback(
@@ -218,17 +220,22 @@ const ChatInterfaceContent = memo(function ChatInterfaceContent({
 		savedDraftRef.current = "";
 	}, [setInput]);
 
-	useEffect(() => {
+	const editingMessageIdRef = useRef(editingMessageId);
+	editingMessageIdRef.current = editingMessageId;
+	const cancelEditRef = useRef(cancelEdit);
+	cancelEditRef.current = cancelEdit;
+
+	useMountEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape" && editingMessageId) {
+			if (e.key === "Escape" && editingMessageIdRef.current) {
 				e.preventDefault();
-				cancelEdit();
+				cancelEditRef.current();
 			}
 		};
 
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [cancelEdit, editingMessageId]);
+	});
 
 	const handleSubmitWithDraftClear = useCallback(
 		async (message: PromptInputMessage) => {

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useConversationScroll, Conversation, ConversationContent } from "@/components/ai-elements/conversation";
@@ -14,7 +15,7 @@ function AutoScroll({ messageCount }: { messageCount: number }) {
 	const prevCountRef = useRef(messageCount);
 	const initialScrollDone = useRef(false);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (messageCount > 0 && !initialScrollDone.current) {
 			initialScrollDone.current = true;
 			requestAnimationFrame(() => {
@@ -62,7 +63,7 @@ export interface ChatMessageListProps {
 }
 
 export const ChatMessageList = memo(function ChatMessageList({
-	chatId,
+	chatId: _chatId,
 	messages,
 	isLoading,
 	isNewChat,
@@ -73,14 +74,6 @@ export const ChatMessageList = memo(function ChatMessageList({
 	onStartEdit,
 }: ChatMessageListProps) {
 	const [openByMessageId, setOpenByMessageId] = useState<Record<string, boolean>>({});
-
-	const prevChatIdRef = useRef(chatId);
-	useEffect(() => {
-		if (prevChatIdRef.current !== chatId) {
-			setOpenByMessageId({});
-			prevChatIdRef.current = chatId;
-		}
-	}, [chatId]);
 	const prevThinkingStreamingByMessageIdRef = useRef<Record<string, boolean>>({});
 
 	const processedMessages = useMemo(() => {
@@ -192,7 +185,7 @@ export const ChatMessageList = memo(function ChatMessageList({
 		});
 	}, [messages]);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		const prevThinkingStreamingByMessageId = prevThinkingStreamingByMessageIdRef.current;
 		setOpenByMessageId((prev) => {
 			let changed = false;

--- a/apps/web/src/components/chat/prompt-toolbar.tsx
+++ b/apps/web/src/components/chat/prompt-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
 import { ArrowUpIcon, BrainIcon, GlobeIcon, SquareIcon } from "lucide-react";
@@ -63,7 +63,7 @@ export function ReasoningToggleButton({ disabled }: ToolbarToggleProps) {
 	const capabilities = getModelCapabilities(selectedModelId, currentModel);
 	const supportsReasoning = capabilities.supportsReasoning;
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!supportsReasoning && reasoningEnabled) {
 			setReasoningEnabled(false);
 		}
@@ -105,7 +105,7 @@ export function WebSearchToggleButton({ disabled }: ToolbarToggleProps) {
 		? !backendSearchAvailability.canSearch
 		: localIsLimitReached;
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!isConfigured && webSearchEnabled) {
 			setWebSearchEnabled(false);
 		}

--- a/apps/web/src/components/model-selector.tsx
+++ b/apps/web/src/components/model-selector.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useDeferredValue, useLayoutEffect, useRef, useState } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import { createPortal, flushSync } from "react-dom";
 import type { Model } from "@/stores/model";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -73,7 +74,7 @@ export function ModelSelector({
 	const filteredModels = useFilteredModels(models, deferredQuery, selectedProvider, showFavoritesOnly, favorites);
 	const flatList = useFlatList(filteredModels);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		setHighlightedIndex(-1);
 	}, [deferredQuery, selectedProvider, showFavoritesOnly]);
 
@@ -147,7 +148,7 @@ export function ModelSelector({
 		[toggleFavorite],
 	);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!open) return;
 
 		function handleKeyDown(e: KeyboardEvent) {
@@ -181,7 +182,7 @@ export function ModelSelector({
 		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, [open, flatList, highlightedIndex, handleSelect, handleClose]);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!listRef.current || !open) return;
 		const selectedElement = listRef.current.querySelector(`[data-index="${highlightedIndex}"]`);
 		if (selectedElement) {
@@ -189,13 +190,13 @@ export function ModelSelector({
 		}
 	}, [highlightedIndex, open]);
 
-	useEffect(() => {
+	useMountEffect(() => {
 		return () => {
 			if (infoHoverTimerRef.current) clearTimeout(infoHoverTimerRef.current);
 		};
-	}, []);
+	});
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!open) return;
 
 		function handleClickOutside(e: MouseEvent) {

--- a/apps/web/src/components/openrouter-connect-modal.tsx
+++ b/apps/web/src/components/openrouter-connect-modal.tsx
@@ -5,7 +5,8 @@
  * Used from Settings page when user wants to connect their own API key.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { CheckIcon, ExternalLinkIcon, KeyIcon, XIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import { useOpenRouterKey } from "@/stores/openrouter";
@@ -29,7 +30,7 @@ export function OpenRouterConnectModal({ open, onOpenChange }: OpenRouterConnect
 	}, [onOpenChange]);
 
 	// Close modal when API key is set (successful connection)
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (hasApiKey && open) {
 			// Small delay to show success state
 			const timer = setTimeout(() => {
@@ -40,7 +41,7 @@ export function OpenRouterConnectModal({ open, onOpenChange }: OpenRouterConnect
 	}, [hasApiKey, open, onOpenChange]);
 
 	// Handle Escape key to close modal
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!open) return;
 		function handleKeyDown(e: KeyboardEvent) {
 			if (e.key === "Escape") {

--- a/apps/web/src/components/settings/settings-providers.tsx
+++ b/apps/web/src/components/settings/settings-providers.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import type { MouseEvent } from "react";
 import { useOpenRouterKey } from "@/stores/openrouter";
 import { DAILY_LIMIT_CENTS, isPreviewDeployment, useProviderStore } from "@/stores/provider";
@@ -14,7 +15,7 @@ export function ProvidersSection() {
 	const remainingBudget = useProviderStore((s) => s.remainingBudgetCents());
 	const [connectModalOpen, setConnectModalOpen] = useState(false);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!isInitialized) {
 			void initialize();
 		}

--- a/apps/web/src/components/settings/settings-shortcuts.tsx
+++ b/apps/web/src/components/settings/settings-shortcuts.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useShortcutsStore } from "@/stores/shortcuts";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,7 +38,7 @@ export function ShortcutsSection() {
 		}));
 	}, []);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!recordingId) return;
 
 		const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/web/src/components/shortcuts-dialog.tsx
+++ b/apps/web/src/components/shortcuts-dialog.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useNavigate } from "@tanstack/react-router";
 import { CircleHelpIcon, SearchIcon, SettingsIcon, XIcon } from "lucide-react";
 import {
@@ -50,7 +51,7 @@ export function ShortcutsDialog({ showHelpButton }: { showHelpButton: boolean })
 	const [search, setSearch] = useState("");
 
 	// Reset search when dialog opens
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (shortcutsDialogOpen) {
 			setSearch("");
 		}

--- a/apps/web/src/components/sidebar/use-sidebar-actions.ts
+++ b/apps/web/src/components/sidebar/use-sidebar-actions.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { api } from "@server/convex/_generated/api";
@@ -62,6 +63,12 @@ export function useSidebarActions({
 	const getSelectedChatIds = useBulkSelectionStore((s) => s.getSelectedChatIds);
 	const selectionAnchorRef = useRef<string | null>(null);
 	const shareRequestIdRef = useRef(0);
+
+	contextMenuRef.current = contextMenu;
+	const deselectAllRef = useRef(deselectAll);
+	deselectAllRef.current = deselectAll;
+	const selectedChatIdsRef = useRef(selectedChatIds);
+	selectedChatIdsRef.current = selectedChatIds;
 
 	const deleteChat = useMemo(
 		() => (deleteChatId ? chats.find((chat) => chat._id === deleteChatId) : null),
@@ -373,11 +380,7 @@ export function useSidebarActions({
 		[confirmDelete, handleDeleteChat],
 	);
 
-	useEffect(() => {
-		contextMenuRef.current = contextMenu;
-	}, [contextMenu]);
-
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (typeof window === "undefined") return;
 		if (!contextMenu || !contextMenuElementRef.current) return;
 		const rect = contextMenuElementRef.current.getBoundingClientRect();
@@ -391,14 +394,14 @@ export function useSidebarActions({
 		}
 	}, [contextMenu]);
 
-	useEffect(() => {
+	useMountEffect(() => {
 		isMountedRef.current = true;
 		return () => {
 			isMountedRef.current = false;
 		};
-	}, []);
+	});
 
-	useEffect(() => {
+	useMountEffect(() => {
 		const handleDismiss = () => {
 			if (!contextMenuRef.current) return;
 			if (!isMountedRef.current) return;
@@ -411,8 +414,8 @@ export function useSidebarActions({
 				setContextMenu(null);
 				setDeleteChatId(null);
 			}
-			if (event.key === "Escape" && selectedChatIds.size > 0) {
-				deselectAll();
+			if (event.key === "Escape" && selectedChatIdsRef.current.size > 0) {
+				deselectAllRef.current();
 			}
 		};
 
@@ -425,7 +428,7 @@ export function useSidebarActions({
 			window.removeEventListener("contextmenu", handleDismiss);
 			window.removeEventListener("keydown", handleKey);
 		};
-	}, [deselectAll, selectedChatIds.size]);
+	});
 
 	return {
 		contextMenu,

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import { useRender } from "@base-ui/react/use-render"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useMountEffect } from "@/hooks/use-mount-effect"
 import { SHORTCUT_EVENT_TOGGLE_SIDEBAR } from "@/lib/shortcuts"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -92,15 +93,18 @@ function SidebarProvider({
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
+  const toggleSidebarRef = React.useRef(toggleSidebar)
+  toggleSidebarRef.current = toggleSidebar
+
   // Listens for global shortcut events to toggle the sidebar.
-  React.useEffect(() => {
+  useMountEffect(() => {
     const onShortcutToggle = () => {
-      toggleSidebar()
+      toggleSidebarRef.current()
     }
 
     window.addEventListener(SHORTCUT_EVENT_TOGGLE_SIDEBAR, onShortcutToggle)
     return () => window.removeEventListener(SHORTCUT_EVENT_TOGGLE_SIDEBAR, onShortcutToggle)
-  }, [toggleSidebar])
+  })
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.

--- a/apps/web/src/hooks/__tests__/use-persistent-chat.test.ts
+++ b/apps/web/src/hooks/__tests__/use-persistent-chat.test.ts
@@ -533,7 +533,7 @@ describe("message loading state", () => {
 		expect(result.current.isLoadingMessages).toBe(false);
 	});
 
-	it("messages are populated from Convex result via useEffect", async () => {
+	it("messages are populated from Convex result via useEffectOnDeps", async () => {
 		mockMessagesResult = [
 			{
 				_id: "server-msg-1",

--- a/apps/web/src/hooks/use-chat-messages.ts
+++ b/apps/web/src/hooks/use-chat-messages.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
 import type { Id } from "@server/convex/_generated/dataModel";
@@ -28,7 +28,7 @@ export function useChatMessages({
 		chatId && convexUserId ? { chatId: chatId as Id<"chats">, userId: convexUserId } : "skip",
 	);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!messagesResult || status === "streaming" || status === "submitted") return;
 
 		setMessages((prevMessages) => {

--- a/apps/web/src/hooks/use-chat-streaming.ts
+++ b/apps/web/src/hooks/use-chat-streaming.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
 import type { Id } from "@server/convex/_generated/dataModel";
@@ -36,7 +37,7 @@ export function useChatStreaming({
 		chatId && convexUserId ? { chatId: chatId as Id<"chats">, userId: convexUserId } : "skip",
 	);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (!activeStreamJob) {
 			if (status === "streaming" || status === "submitted") {
 				if (streamingRef.current) {

--- a/apps/web/src/hooks/use-favorite-models.ts
+++ b/apps/web/src/hooks/use-favorite-models.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useAuth } from "@/lib/auth-client";
 
 const DEFAULT_FAVORITES = [
@@ -49,7 +50,7 @@ export function useFavoriteModels() {
     setFavorites(new Set(nextFavorites));
   }, []);
 
-  useEffect(() => {
+  useEffectOnDeps(() => {
     if (!convexUserId) {
       activeUserIdRef.current = null;
       lastServerSnapshotRef.current = null;

--- a/apps/web/src/hooks/use-global-shortcuts.ts
+++ b/apps/web/src/hooks/use-global-shortcuts.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo } from "react";
+import { useMemo, useRef } from "react";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import type { NavigateFn } from "@tanstack/react-router";
 import {
 	type ShortcutActionId,
@@ -128,27 +129,37 @@ export function useGlobalShortcuts({ navigate, isAuthenticated, pathname }: UseG
 	const isMac = useMemo(() => isMacPlatform(), []);
 	const onChatRoute = isChatRoute(pathname);
 
-	useEffect(() => {
-		const bindingMap = getEffectiveBindingsMap(bindings, isMac);
+	const bindingsRef = useRef(bindings);
+	bindingsRef.current = bindings;
+	const isAuthenticatedRef = useRef(isAuthenticated);
+	isAuthenticatedRef.current = isAuthenticated;
+	const navigateRef = useRef(navigate);
+	navigateRef.current = navigate;
+	const onChatRouteRef = useRef(onChatRoute);
+	onChatRouteRef.current = onChatRoute;
+	const isMacRef = useRef(isMac);
+	isMacRef.current = isMac;
 
+	useMountEffect(() => {
 		function onKeyDown(event: KeyboardEvent) {
 			if (event.defaultPrevented || event.repeat || event.isComposing) return;
 
+			const bindingMap = getEffectiveBindingsMap(bindingsRef.current, isMacRef.current);
 			const currentBinding = eventToBinding(event);
 			if (!currentBinding) return;
 
 			const matched: ShortcutDefinition | undefined = bindingMap.get(currentBinding);
 			if (!matched) return;
 
-			if (!isAuthenticated) return;
-			if (!onChatRoute && CHAT_ONLY_SHORTCUTS.has(matched.id)) return;
+			if (!isAuthenticatedRef.current) return;
+			if (!onChatRouteRef.current && CHAT_ONLY_SHORTCUTS.has(matched.id)) return;
 			if (isEditableElement(event.target) && !matched.allowInInput) return;
 
 			event.preventDefault();
-			runShortcutAction(matched.id, navigate);
+			runShortcutAction(matched.id, navigateRef.current);
 		}
 
 		document.addEventListener("keydown", onKeyDown);
 		return () => document.removeEventListener("keydown", onKeyDown);
-	}, [bindings, isAuthenticated, isMac, navigate, onChatRoute]);
+	});
 }

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -1,11 +1,12 @@
 import * as React from "react"
+import { useMountEffect } from "@/hooks/use-mount-effect"
 
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
-  React.useEffect(() => {
+  useMountEffect(() => {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
@@ -30,7 +31,7 @@ export function useIsMobile() {
         window.removeEventListener("resize", onChange)
       }
     }
-  }, [])
+  })
 
   return !!isMobile
 }

--- a/apps/web/src/hooks/use-mount-effect.ts
+++ b/apps/web/src/hooks/use-mount-effect.ts
@@ -1,0 +1,18 @@
+import { useEffect, type DependencyList, type EffectCallback } from "react";
+
+/**
+ * AGENTS.md Rule 1: Mount/unmount external side effects only (DOM listeners, third-party init).
+ * Do not import `useEffect` from "react" in app code — use this or `useEffectOnDeps`.
+ */
+export function useMountEffect(effect: EffectCallback): void {
+	useEffect(effect, []);
+}
+
+/**
+ * AGENTS.md Rule 1: External side effects that legitimately depend on values changing
+ * (Convex/auth sync, query-driven UI updates). Prefer derived state, event handlers, or
+ * TanStack Query when possible. Call sites should include a short comment when non-obvious.
+ */
+export function useEffectOnDeps(effect: EffectCallback, deps: DependencyList): void {
+	useEffect(effect, deps);
+}

--- a/apps/web/src/hooks/use-persistent-chat.ts
+++ b/apps/web/src/hooks/use-persistent-chat.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useQuery } from "convex/react";
 import { api } from "@server/convex/_generated/api";
 import type { UIMessage } from "ai";
@@ -49,12 +50,9 @@ export function usePersistentChat({
 	const chatIdRef = useRef<string | null>(chatId ?? null);
 	const streamingRef = useRef<StreamingState | null>(null);
 	const onChatCreatedRef = useRef(onChatCreated);
+	onChatCreatedRef.current = onChatCreated;
 
-	useEffect(() => {
-		onChatCreatedRef.current = onChatCreated;
-	}, [onChatCreated]);
-
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		if (chatId) {
 			chatIdRef.current = chatId;
 			setCurrentChatId(chatId);

--- a/apps/web/src/hooks/use-prompt-draft.ts
+++ b/apps/web/src/hooks/use-prompt-draft.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { usePromptDraftStore } from "@/stores/prompt-draft";
 
 /**
@@ -42,7 +43,7 @@ export function usePromptDraft({ chatId, textInputController }: UsePromptDraftOp
 	const skipNextSaveRef = useRef(false);
 
 	// Restore draft on mount or when chatId changes
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		// Reset restoration flag when chatId changes
 		hasRestoredRef.current = false;
 		skipNextSaveRef.current = true;
@@ -72,7 +73,7 @@ export function usePromptDraft({ chatId, textInputController }: UsePromptDraftOp
 
 	// Sync text changes to sessionStorage (debounced)
 	// Using chatId and setDraft directly to avoid re-running on saveDraft recreation
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		// Only save after initial restoration
 		if (!hasRestoredRef.current) {
 			return;

--- a/apps/web/src/hooks/use-smooth-text.ts
+++ b/apps/web/src/hooks/use-smooth-text.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 
 // Each frame reveals ~1/K of the remaining queue.
 // K=8 at 60fps drains a 100-char burst in ~330ms — fast enough to feel linear,
@@ -55,7 +56,7 @@ export function useSmoothText(
 		rafRef.current = requestAnimationFrame(tick);
 	}, []);
 
-	useEffect(() => {
+	useEffectOnDeps(() => {
 		const shouldSkipInitialAnimation =
 			options?.skipInitialAnimation === true &&
 			!hasHandledInitialSyncRef.current &&
@@ -94,12 +95,12 @@ export function useSmoothText(
 		ensureRunning();
 	}, [text, isStreaming, ensureRunning, options?.skipInitialAnimation]);
 
-	useEffect(() => {
+	useMountEffect(() => {
 		return () => {
 			cancelAnimationFrame(rafRef.current);
 			runningRef.current = false;
 		};
-	}, []);
+	});
 
 	return displayed;
 }

--- a/apps/web/src/lib/auth-client.tsx
+++ b/apps/web/src/lib/auth-client.tsx
@@ -3,7 +3,6 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useRef,
   useState
 } from "react";
@@ -14,7 +13,8 @@ import {
 } from "@convex-dev/better-auth/client/plugins";
 import { env } from "./env";
 import { analytics } from "./analytics";
-import type {ReactNode} from "react";
+import type { ReactNode } from "react";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 
 
 /**
@@ -125,7 +125,7 @@ export function StableAuthProvider({
     }
   }, []);
 
-  useEffect(() => {
+  useMountEffect(() => {
     if (fetchedRef.current) return;
     fetchedRef.current = true;
 
@@ -150,7 +150,7 @@ export function StableAuthProvider({
     } else {
       fetchSession();
     }
-  }, [fetchSession]);
+  });
 
   const value: AuthContextValue = {
     user: sessionData.user,

--- a/apps/web/src/providers/index.tsx
+++ b/apps/web/src/providers/index.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ConvexProviderWithAuth, useMutation, useQuery } from "convex/react";
 import { Toaster } from "sonner";
@@ -50,7 +51,7 @@ const queryClient = new QueryClient({
 });
 
 interface ProvidersProps {
-  children: React.ReactNode;
+  children: ReactNode;
   initialUser?: InitialAuthUser;
 }
 
@@ -78,26 +79,26 @@ function useStableConvexAuth() {
  * This is CRITICAL - without this, convexUserId will be undefined
  * and message sending will silently fail.
  */
-function UserSyncProvider({ children }: { children: React.ReactNode }) {
+function UserSyncProvider({ children }: { children: ReactNode }) {
   const { user, isAuthenticated, loading } = useAuth();
+  // @ts-expect-error TS2589 — Convex `useMutation(api.users.ensure)` hits excessive instantiation depth under this workspace's tsc settings.
   const ensureUser = useMutation(api.users.ensure);
   const syncedUserIdRef = useRef<string | null>(null);
   const syncingUserIdRef = useRef<string | null>(null);
 
-  useEffect(() => {
+  // Imperative Convex ensureUser when Better Auth identity loads or changes (no user gesture).
+  useEffectOnDeps(() => {
     if (!isAuthenticated || !user?.id) {
       syncedUserIdRef.current = null;
       syncingUserIdRef.current = null;
+      return;
     }
-  }, [isAuthenticated, user?.id]);
 
-  useEffect(() => {
     const userId = user?.id;
 
     // Only sync once when user is authenticated and we have user data
     if (
       loading ||
-      !isAuthenticated ||
       !userId ||
       syncedUserIdRef.current === userId ||
       syncingUserIdRef.current === userId
@@ -132,7 +133,7 @@ function UserSyncProvider({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-function UsageSyncProvider({ children }: { children: React.ReactNode }) {
+function UsageSyncProvider({ children }: { children: ReactNode }) {
   const { user, isAuthenticated, loading } = useAuth();
   const syncUsage = useProviderStore((s) => s.syncUsage);
   const resetDailyUsage = useProviderStore((s) => s.resetDailyUsage);
@@ -141,7 +142,8 @@ function UsageSyncProvider({ children }: { children: React.ReactNode }) {
     !loading && isAuthenticated && user?.id ? { externalId: user.id } : "skip",
   );
 
-  useEffect(() => {
+  // Push server usage limits into client Zustand when Convex user doc updates.
+  useEffectOnDeps(() => {
     if (!isAuthenticated || !user?.id) {
       resetDailyUsage();
       return;
@@ -167,26 +169,25 @@ function UsageSyncProvider({ children }: { children: React.ReactNode }) {
  * Component that checks OpenRouter API key status from the server.
  * This syncs the hasApiKey state without exposing the actual key to the client.
  */
-function OpenRouterKeyStatusProvider({ children }: { children: React.ReactNode }) {
+function OpenRouterKeyStatusProvider({ children }: { children: ReactNode }) {
 	const { user, isAuthenticated, loading } = useAuth();
 	const initialize = useOpenRouterStore((s) => s.initialize);
 	const checkedUserIdRef = useRef<string | null>(null);
 	const checkingUserIdRef = useRef<string | null>(null);
 
-  useEffect(() => {
+  // Server round-trip for OpenRouter key presence; tied to auth identity, not a click handler.
+  useEffectOnDeps(() => {
     if (!isAuthenticated || !user?.id) {
       checkedUserIdRef.current = null;
       checkingUserIdRef.current = null;
+      return;
     }
-  }, [isAuthenticated, user?.id]);
 
-  useEffect(() => {
     const userId = user?.id;
 
     // Only check once when user is authenticated
     if (
       loading ||
-      !isAuthenticated ||
       !userId ||
       checkedUserIdRef.current === userId ||
       checkingUserIdRef.current === userId
@@ -215,7 +216,7 @@ function OpenRouterKeyStatusProvider({ children }: { children: React.ReactNode }
   return <>{children}</>;
 }
 
-function ConvexAuthWrapper({ children }: { children: React.ReactNode }) {
+function ConvexAuthWrapper({ children }: { children: ReactNode }) {
   return (
     <ConvexProviderWithAuth client={convexClient!} useAuth={useStableConvexAuth}>
       <UserSyncProvider>
@@ -227,12 +228,16 @@ function ConvexAuthWrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function Providers({ children, initialUser }: ProvidersProps) {
-  const [isClient, setIsClient] = useState(false);
+function useIsClient(): boolean {
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+}
 
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+export function Providers({ children, initialUser }: ProvidersProps) {
+  const isClient = useIsClient();
 
   const content = (
     <ThemeProvider>

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -2,7 +2,7 @@
  * PostHog Analytics Provider
  */
 
-import { useEffect } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { env } from "@/lib/env";
@@ -26,9 +26,9 @@ function initPostHog() {
 }
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
+  useMountEffect(() => {
     initPostHog();
-  }, []);
+  });
 
   // If no PostHog key, just render children without provider
   if (!env.POSTHOG_KEY) {
@@ -71,7 +71,7 @@ function getSanitizedUrl(): string {
 
 // Hook to capture page views (call this in your router)
 export function usePostHogPageView(pathname: string) {
-  useEffect(() => {
+  useEffectOnDeps(() => {
     if (env.POSTHOG_KEY && posthogInitialized) {
       posthog.capture("$pageview", {
         $current_url: getSanitizedUrl(),

--- a/apps/web/src/providers/theme-provider.tsx
+++ b/apps/web/src/providers/theme-provider.tsx
@@ -5,7 +5,8 @@
  * This provider just manages the React state for theme switching.
  */
 
-import { createContext, useEffect, useState } from "react";
+import { createContext, useState, useSyncExternalStore } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 
 type Theme = "dark" | "light" | "system";
 
@@ -19,11 +20,6 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 const STORAGE_KEY = "openchat-theme";
 
-function getSystemTheme(): "dark" | "light" {
-  if (typeof window === "undefined") return "dark";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
 function getStoredTheme(): Theme {
   if (typeof window === "undefined") return "system";
   const stored = localStorage.getItem(STORAGE_KEY);
@@ -33,42 +29,32 @@ function getStoredTheme(): Theme {
   return "system";
 }
 
-// Get initial resolved theme (matches inline script logic)
-function getInitialResolved(): "dark" | "light" {
+function subscribeSystemTheme(cb: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  mq.addEventListener("change", cb);
+  return () => mq.removeEventListener("change", cb);
+}
+
+function getSystemThemeSnapshot(): "dark" | "light" {
   if (typeof window === "undefined") return "dark";
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored === "dark" || stored === "light") return stored;
-  return getSystemTheme();
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(getStoredTheme);
-  const [resolvedTheme, setResolvedTheme] = useState<"dark" | "light">(getInitialResolved);
+  const systemTheme = useSyncExternalStore(
+    subscribeSystemTheme,
+    getSystemThemeSnapshot,
+    () => "dark" as const,
+  );
+  const resolvedTheme: "dark" | "light" = theme === "system" ? systemTheme : theme;
 
-  // Update document class when theme changes
-  useEffect(() => {
-    const resolved = theme === "system" ? getSystemTheme() : theme;
-    setResolvedTheme(resolved);
-
+  // Sync resolved theme to document (external DOM; must run after paint).
+  useEffectOnDeps(() => {
     document.documentElement.classList.remove("light", "dark");
-    document.documentElement.classList.add(resolved);
-  }, [theme]);
-
-  // Listen for system theme changes when in system mode
-  useEffect(() => {
-    if (theme !== "system") return;
-
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = (e: MediaQueryListEvent) => {
-      const newTheme = e.matches ? "dark" : "light";
-      setResolvedTheme(newTheme);
-      document.documentElement.classList.remove("light", "dark");
-      document.documentElement.classList.add(newTheme);
-    };
-
-    mediaQuery.addEventListener("change", handler);
-    return () => mediaQuery.removeEventListener("change", handler);
-  }, [theme]);
+    document.documentElement.classList.add(resolvedTheme);
+  }, [resolvedTheme]);
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);

--- a/apps/web/src/routes/auth/callback.tsx
+++ b/apps/web/src/routes/auth/callback.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useEffectOnDeps } from "@/hooks/use-mount-effect";
 import { useAuth } from "../../lib/auth-client";
 
 export const Route = createFileRoute("/auth/callback")({
@@ -18,7 +19,7 @@ function AuthCallbackPage() {
   const [error, setError] = useState<string | null>(null);
   const [attempts, setAttempts] = useState(0);
 
-  useEffect(() => {
+  useEffectOnDeps(() => {
     // Check URL for error params
     const params = new URLSearchParams(window.location.search);
     const errorParam = params.get("error");

--- a/apps/web/src/routes/auth/sign-in.tsx
+++ b/apps/web/src/routes/auth/sign-in.tsx
@@ -2,7 +2,8 @@
  * Sign In Page - GitHub OAuth authentication
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
   signInWithEmail,
@@ -151,14 +152,14 @@ function SignInPage() {
   const [stats, setStats] = useState<PublicStats | null>(cachedStats);
 
   // Redirect if already authenticated
-  useEffect(() => {
+  useEffectOnDeps(() => {
     if (!loading && isAuthenticated) {
       navigate({ to: "/" });
     }
   }, [loading, isAuthenticated, navigate]);
 
   // Fetch real stats from backend (cached)
-  useEffect(() => {
+  useMountEffect(() => {
     // Use cache if fresh
     if (cachedStats && Date.now() - cacheTimestamp < CACHE_TTL) {
       setStats(cachedStats);
@@ -178,7 +179,7 @@ function SignInPage() {
         }
       })
       .catch(() => null);
-  }, []);
+  });
 
   // Fallback stats while loading
   const displayStats = stats || {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { Link, createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import { useAuth } from "../lib/auth-client";
 import { Button } from "../components/ui/button";
 import { ChatInterface } from "../components/chat";
@@ -40,7 +41,7 @@ function InteractiveStaircase({
   )
   const [layout, setLayout] = useState({ gridSize: 12, squareSize: 40 })
 
-  useEffect(() => {
+  useMountEffect(() => {
     const updateLayout = () => {
       if (containerRef.current) {
         const rect = containerRef.current.getBoundingClientRect()
@@ -63,7 +64,7 @@ function InteractiveStaircase({
       cancelAnimationFrame(rafId)
       window.removeEventListener('resize', updateLayout)
     }
-  }, [])
+  })
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     // Use cached rect to avoid getBoundingClientRect on every mouse move
@@ -219,7 +220,7 @@ function HomePage() {
   const { isAuthenticated, loading } = useAuth();
 
   // Load autochangelog in-app widget only on root page for authenticated users
-  useEffect(() => {
+  useEffectOnDeps(() => {
     if (!isAuthenticated) return;
 
     const scriptId = 'autochangelog-in-app';

--- a/apps/web/src/routes/openrouter/callback.tsx
+++ b/apps/web/src/routes/openrouter/callback.tsx
@@ -6,7 +6,8 @@
  */
 
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useEffectOnDeps, useMountEffect } from "@/hooks/use-mount-effect";
 import { useOpenRouterKey } from "../../stores/openrouter";
 import {
   Card,
@@ -47,12 +48,12 @@ function OpenRouterCallbackPage() {
   const processedRef = useRef(false);
 
   // Prevent hydration mismatch by only running client-side logic after mount
-  useEffect(() => {
+  useMountEffect(() => {
     setMounted(true);
-  }, []);
+  });
 
   // Handle the OAuth callback (with guard against double-execution from Strict Mode)
-  useEffect(() => {
+  useEffectOnDeps(() => {
     if (!mounted || processedRef.current) return;
     processedRef.current = true;
 

--- a/apps/web/src/stores/model.ts
+++ b/apps/web/src/stores/model.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { analytics } from "@/lib/analytics";
@@ -7,7 +8,7 @@ export type { Model, ModelCapabilities, ReasoningEffort } from "./model-data";
 export { getCacheStatus, getModelById, getModelCapabilities, prefetchModels } from "./model-utils";
 
 import type { Model } from "./model-data";
-import { CACHE_TTL, cache, fetchAllModels, getFallbackModels, reloadModels, subscribe } from "./model-utils";
+import { cache, fetchAllModels, getFallbackModels, reloadModels, subscribe } from "./model-utils";
 
 type ReasoningEffort = "none" | "low" | "medium" | "high";
 
@@ -129,60 +130,27 @@ export const useModelStore = create<ModelState>()(
 );
 
 export function useModels() {
-	const [models, setModels] = useState<Array<Model>>(() => cache.models || getFallbackModels());
-	const [isLoading, setIsLoading] = useState(() => cache.loading || !cache.models);
-	const [error, setError] = useState<Error | null>(() => cache.error);
 	const [, forceUpdate] = useState(0);
 
-	useEffect(() => {
-		return subscribe(() => forceUpdate((n) => n + 1));
-	}, []);
+	useMountEffect(() => {
+		const unsubscribe = subscribe(() => {
+			forceUpdate((n) => n + 1);
+		});
+		void fetchAllModels().catch(() => {
+			/* Errors are stored on `cache` by fetchAllModels; avoid unhandled rejection */
+		});
+		return unsubscribe;
+	});
 
-	useEffect(() => {
-		let cancelled = false;
-
-		async function load() {
-			if (cache.models && Date.now() - cache.timestamp < CACHE_TTL) {
-				setModels(cache.models);
-				setIsLoading(false);
-				setError(null);
-				return;
-			}
-
-			setIsLoading(true);
-
-			try {
-				const fetched = await fetchAllModels();
-				if (!cancelled) {
-					setModels(fetched);
-					setError(null);
-				}
-			} catch (e) {
-				if (!cancelled) {
-					setError(e instanceof Error ? e : new Error("Failed"));
-					setModels(getFallbackModels());
-				}
-			} finally {
-				if (!cancelled) setIsLoading(false);
-			}
-		}
-
-		load();
-		return () => {
-			cancelled = true;
-		};
-	}, []);
+	const models = cache.models ?? getFallbackModels();
+	const isLoading = cache.loading;
+	const error = cache.error;
 
 	const reload = useCallback(async () => {
-		setIsLoading(true);
-		setError(null);
 		try {
-			const fetched = await reloadModels();
-			setModels(fetched);
-		} catch (e) {
-			setError(e instanceof Error ? e : new Error("Failed"));
-		} finally {
-			setIsLoading(false);
+			await reloadModels();
+		} catch {
+			/* cache.error set by fetch path; subscribe notifies */
 		}
 	}, []);
 

--- a/apps/web/src/stores/openrouter.ts
+++ b/apps/web/src/stores/openrouter.ts
@@ -232,7 +232,7 @@ export const useOpenRouterStore = create<OpenRouterState>()(
  *   const { hasApiKey, initiateLogin, clearApiKey, initialize, isInitialized } = useOpenRouterKey();
  *
  *   // Initialize on mount to check server for existing key
- *   useEffect(() => {
+ *   useEffectOnDeps(() => {
  *     if (!isInitialized) {
  *       initialize();
  *     }

--- a/apps/web/src/test-session.test.tsx
+++ b/apps/web/src/test-session.test.tsx
@@ -1,16 +1,16 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
-import { useEffect } from 'react'
+import { useMountEffect } from '@/hooks/use-mount-effect'
 
 function TestComp() {
-  useEffect(() => {
+  useMountEffect(() => {
     try {
       sessionStorage.getItem('test-key')
     } catch (e) {
       console.warn('caught error', e)
     }
-  }, [])
+  })
   return <div>test</div>
 }
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -35,8 +35,8 @@ const sessionStorageMock = (() => {
 	};
 })();
 
-global.localStorage = localStorageMock as any;
-global.sessionStorage = sessionStorageMock as any;
+globalThis.localStorage = localStorageMock as unknown as Storage;
+globalThis.sessionStorage = sessionStorageMock as unknown as Storage;
 
 // Mock window and document globals for browser environment
 if (typeof window !== "undefined") {
@@ -64,7 +64,7 @@ global.IntersectionObserver = class IntersectionObserver {
 		return [];
 	}
 	unobserve() {}
-} as any;
+} as unknown as typeof IntersectionObserver;
 
 // Mock ResizeObserver
 global.ResizeObserver = class ResizeObserver {
@@ -72,7 +72,7 @@ global.ResizeObserver = class ResizeObserver {
 	disconnect() {}
 	observe() {}
 	unobserve() {}
-} as any;
+} as unknown as typeof ResizeObserver;
 
 // Cleanup after each test case
 afterEach(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the repository’s updated **AGENTS.md** rules around React effects and a few related cleanups.

### 1. Direct `useEffect` → `useMountEffect` / `useEffectOnDeps`
- Added [`apps/web/src/hooks/use-mount-effect.ts`](apps/web/src/hooks/use-mount-effect.ts): the **only** modules that import `useEffect` from `react` are this file’s `useMountEffect` (empty deps) and `useEffectOnDeps` (explicit deps).
- Migrated all previous `useEffect` usage across web routes, providers, hooks, and UI/ai-elements to those helpers.

### 2. Effect patterns addressed where straightforward
- **Rule 6 (reset on id):** `ChatInterfaceContent` is keyed by `chatId` so edit state resets without a `chatId` effect; redundant `chatId`→`openByMessageId` reset removed from `ChatMessageList` (parent key handles it).
- **Stable listeners:** global shortcuts, chat shortcut listeners, sidebar toggle, and similar use **refs + `useMountEffect`** instead of re-subscribing on changing deps.
- **`useModels`:** Dropped fetch-in-effect + duplicate React state; models/error come from the existing module `cache` + `subscribe`, with `isLoading = cache.loading` and `.catch()` on `fetchAllModels()` to avoid unhandled rejections after unmount.
- **Theme:** System preference via `useSyncExternalStore`; document class sync uses `useEffectOnDeps`.
- **SSR/client:** `Providers` uses `useSyncExternalStore` instead of `useState` + `useEffect` for client detection.

### 3. `as any` reductions
- [`test/setup.ts`](test/setup.ts): `Storage` / observer constructors via `unknown` double assertion.
- [`apps/server/convex/__tests__/backgroundStream.test.ts`](apps/server/convex/__tests__/backgroundStream.test.ts): removed `ctx.db as any` / `q: any` in indexed queries.

### Note
- **`routeTree.gen.ts`** and many test mocks still contain `as any` (generated or low-level mocks); not changed in this PR.
- **`UserSyncProvider`:** `@ts-expect-error TS2589` on `useMutation(api.users.ensure)` — Convex + tsc instantiation depth in this workspace; behavior unchanged.

## Verification
- `bun check`
- `bun run test` (full Vitest suite)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e438d3aa-5fe6-478d-a6ea-e2582a5aa72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e438d3aa-5fe6-478d-a6ea-e2582a5aa72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace direct `useEffect` calls with `useMountEffect` and `useEffectOnDeps` wrappers across the web app
> - Adds [`use-mount-effect.ts`](https://github.com/opencoredev/openchat/pull/707/files#diff-555d31b82f3dd55a2639f4c58bdc64a4fae3012a4a0a23a355648f5b6b412d57) exporting `useMountEffect` (mount-only) and `useEffectOnDeps` (dependency-based) as thin wrappers around React's `useEffect`, banning direct `useEffect` usage per AGENTS.md policy.
> - Replaces every `useEffect` call across hooks, components, providers, and routes with the appropriate wrapper; logic and dependency arrays are unchanged in almost all cases.
> - Refactors several hooks (`useGlobalShortcuts`, `useSidebarActions`, `ChatInterfaceContent`) to register event listeners once via `useMountEffect` and read latest values via refs, eliminating stale-closure re-registrations.
> - Adds `key={chatId ?? "__new__"}` to `ChatInterfaceContent` so it fully remounts on chat change, replacing a `useEffect`-based state reset.
> - Replaces `useState`/`useEffect` isClient pattern in [`providers/index.tsx`](https://github.com/opencoredev/openchat/pull/707/files#diff-c85268366e4fa3445ac4c4523e85b35f84e63168ef36eb2be7616292c4de5c2f) with a `useSyncExternalStore`-based `useIsClient` hook.
> - Behavioral Change: `openByMessageId` in `ChatMessageList` is no longer reset when `chatId` changes; the component relies on remounting via the new `key` prop on the parent instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3c8b242. 39 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->