### PR TITLE
fix: isLoading regression and getEffectiveBindingsMap keystroke caching

### DIFF
--- a/apps/web/src/hooks/use-global-shortcuts.ts
+++ b/apps/web/src/hooks/use-global-shortcuts.ts
@@ -129,26 +129,25 @@ export function useGlobalShortcuts({ navigate, isAuthenticated, pathname }: UseG
 	const isMac = useMemo(() => isMacPlatform(), []);
 	const onChatRoute = isChatRoute(pathname);
 
-	const bindingsRef = useRef(bindings);
-	bindingsRef.current = bindings;
+	const bindingMap = useMemo(() => getEffectiveBindingsMap(bindings, isMac), [bindings, isMac]);
+	const bindingMapRef = useRef(bindingMap);
+	bindingMapRef.current = bindingMap;
+
 	const isAuthenticatedRef = useRef(isAuthenticated);
 	isAuthenticatedRef.current = isAuthenticated;
 	const navigateRef = useRef(navigate);
 	navigateRef.current = navigate;
 	const onChatRouteRef = useRef(onChatRoute);
 	onChatRouteRef.current = onChatRoute;
-	const isMacRef = useRef(isMac);
-	isMacRef.current = isMac;
 
 	useMountEffect(() => {
 		function onKeyDown(event: KeyboardEvent) {
 			if (event.defaultPrevented || event.repeat || event.isComposing) return;
 
-			const bindingMap = getEffectiveBindingsMap(bindingsRef.current, isMacRef.current);
 			const currentBinding = eventToBinding(event);
 			if (!currentBinding) return;
 
-			const matched: ShortcutDefinition | undefined = bindingMap.get(currentBinding);
+			const matched: ShortcutDefinition | undefined = bindingMapRef.current.get(currentBinding);
 			if (!matched) return;
 
 			if (!isAuthenticatedRef.current) return;

--- a/apps/web/src/stores/model.ts
+++ b/apps/web/src/stores/model.ts
@@ -143,7 +143,7 @@ export function useModels() {
 	});
 
 	const models = cache.models ?? getFallbackModels();
-	const isLoading = cache.loading;
+	const isLoading = cache.loading || (cache.models === null && cache.error === null);
 	const error = cache.error;
 
 	const reload = useCallback(async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes two regressions introduced in PR #707 (`cursor/code-standards-compliance-d243`).

## Issue 1 — `isLoading` regression in `useModels` hook

**Problem:** After the module-cache refactor, `cache.loading` initializes as `false`. On the first render of `useModels()`, `isLoading` reads `false` even though no models have been fetched yet. There's a brief frame where `isLoading` is incorrectly `false` before the mount effect starts fetching and flips it to `true`.

**Fix:** Derive `isLoading` from the full cache state:
```ts
const isLoading = cache.loading || (cache.models === null && cache.error === null);
```
This ensures `isLoading` is `true` whenever models haven't loaded yet and no error has occurred, covering the initial render before `fetchAllModels()` kicks in.

## Issue 2 — `getEffectiveBindingsMap` recomputed on every keystroke

**Problem:** The `onKeyDown` handler inside `useMountEffect` called `getEffectiveBindingsMap(bindingsRef.current, isMacRef.current)` on every keystroke, creating a new `Map` each time. While not expensive per-call, it's unnecessary work since bindings only change when the user modifies shortcut settings.

**Fix:** Memoize the binding map with `useMemo` and expose it through a ref:
```ts
const bindingMap = useMemo(() => getEffectiveBindingsMap(bindings, isMac), [bindings, isMac]);
const bindingMapRef = useRef(bindingMap);
bindingMapRef.current = bindingMap;
```
The `onKeyDown` handler reads `bindingMapRef.current` instead of recomputing. The map is only rebuilt when `bindings` or `isMac` changes. Removed the now-unnecessary `bindingsRef` and `isMacRef`.

## Verification

- `bun check` — passes (no new lint warnings)
- `bun run test` — all tests pass
- `bun check-types` — no type errors in changed files (pre-existing errors in unrelated files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5630ce92-9ea6-40b3-9829-e6a1bf9a5d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5630ce92-9ea6-40b3-9829-e6a1bf9a5d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isLoading` regression and memoize `getEffectiveBindingsMap` in keydown handler
> - Fixes `isLoading` in [`useModels`](https://github.com/opencoredev/openchat/pull/708/files#diff-892d94ca51e03a44febeabc3931c38d312c194677d6ebfe7f2f1171bb6cedcf9) to return `true` when both `cache.models` and `cache.error` are `null`, covering the initial indeterminate state that was previously not handled.
> - Replaces per-keydown recomputation of the effective binding map in [`useGlobalShortcuts`](https://github.com/opencoredev/openchat/pull/708/files#diff-371834c5db585a3b121c51f9622257aa0141d57a3d8512d8136fe8e65672c5a6) with a `useMemo`-derived map stored in a ref, so the map is only recomputed when `bindings` or `isMac` changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b1cb06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->